### PR TITLE
Use PATCH method instead of PUT for editMutual method

### DIFF
--- a/.changeset/red-groups-sell.md
+++ b/.changeset/red-groups-sell.md
@@ -1,0 +1,6 @@
+---
+"@monorise/react": patch
+"@monorise/core": patch
+---
+
+Amend editMutual method to use PATCH method

--- a/packages/core/controllers/mutual/update-mutual.controller.ts
+++ b/packages/core/controllers/mutual/update-mutual.controller.ts
@@ -26,6 +26,9 @@ export class UpdateMutualController {
         entityId,
         mutualPayload: req.body,
         accountId,
+        options: {
+          returnUpdatedValue: true,
+        },
       });
 
       return res.status(httpStatus.OK).json(mutual);

--- a/packages/react/services/core.service.ts
+++ b/packages/react/services/core.service.ts
@@ -286,7 +286,7 @@ const initCoreService = (
     opts: CommonOptions = {},
   ) => {
     const { mutualApiBaseUrl = MUTUAL_API_BASE_URL } = options;
-    return axios.put<Mutual<B, T>>(
+    return axios.patch<Mutual<B, T>>(
       opts.customUrl ||
         `${mutualApiBaseUrl}/${byEntityType}/${byEntityId}/${entityType}/${entityId}`,
       payload,


### PR DESCRIPTION
- Previous committed and working codes [here](https://github.com/gift-education/sst-services/pull/681/files#diff-6a6b66cf28f64948ace4159a7b3719682f12815001fc29808b048a942b667e9f) from `sst-services` were overlooked in `monorise`

## Issue reported 
https://linear.app/gift-ed/issue/PD-681/[lms]-cohort-track-checklist-status-not-reflected
![image](https://github.com/user-attachments/assets/c8230260-1d31-43fd-a724-1306319e6103)
