### PR TITLE
update local mutual state in editEntity and some minor fix

### DIFF
--- a/.changeset/pretty-coats-tickle.md
+++ b/.changeset/pretty-coats-tickle.md
@@ -1,0 +1,10 @@
+---
+"@monorise/react": patch
+"@monorise/core": patch
+---
+
+- expose `TagRepository` type
+- `listEntitiesByEntity`: added `'#'` at the end of `SK` value to prevent accidentally got unwanted entity (eg.: desire to get `company` entity but returned both `company` & `company-staff` entities)
+- `editEntity`: update local mutual state to latest entity data
+- `useEntities`: expose `lastKey` & `isFirstFetched` attribute
+- `useMutuals`: expose `lastKey` attribute and added `listMore` function

--- a/packages/core/data/Mutual.ts
+++ b/packages/core/data/Mutual.ts
@@ -220,7 +220,7 @@ export class MutualRepository extends Repository {
           S: mutual.byFullEntityId,
         },
         ':SK': {
-          S: mutual.listEntitySK,
+          S: `${mutual.listEntitySK}#`,
         },
         ':nullType': { S: 'NULL' },
       },

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -3,6 +3,7 @@ import { setupCommonRoutes } from './controllers/setupRoutes';
 import { Entity, EntityRepository } from './data/Entity';
 import { Mutual, MutualRepository } from './data/Mutual';
 import { PROJECTION_EXPRESSION } from './data/ProjectionExpression';
+import { TagRepository } from './data/Tag';
 import { StandardError } from './errors/standard-error';
 import { handler as createEntityProcessor } from './processors/create-entity-processor';
 import { handler as mutualProcessor } from './processors/mutual-processor';
@@ -47,6 +48,7 @@ export {
   EntityService,
   Mutual,
   MutualRepository,
+  TagRepository,
   PROJECTION_EXPRESSION,
   createEntityProcessor,
   mutualProcessor,

--- a/packages/react/actions/core.action.ts
+++ b/packages/react/actions/core.action.ts
@@ -272,9 +272,10 @@ const initCoreActions = (
       produce((state) => {
         state.entity[entityType].dataMap.set(data.entityId, data);
 
+        // update mutual's entity data
         for (const key of Object.keys(state.mutual)) {
-          const [byEntity, entity, byId] = key.split('/');
-          if ((entity as any) === entityType) {
+          const [_byEntity, _entityType, _byId] = key.split('/');
+          if ((_entityType as unknown as Entity) === entityType) {
             const mutual = state.mutual[key].dataMap.get(id);
             state.mutual[key].dataMap = new Map(state.mutual[key].dataMap).set(
               id,

--- a/packages/react/services/core.service.ts
+++ b/packages/react/services/core.service.ts
@@ -227,6 +227,7 @@ const initCoreService = (
         feedback: opts.feedback,
         params: {
           chainEntityQuery,
+          ...opts.params,
           ...(opts.noData && { projection: 'no-data' }),
         },
       },


### PR DESCRIPTION
- `editEntity`: update local mutual state to latest entity data
- `useEntities`: expose `lastKey` & `isFirstFetched` attribute
- `useMutuals`: expose `lastKey` attribute and added `listMore` function
- expose `TagRepository` type
- `listEntitiesByEntity`: added `'#'` at the end of `SK` value to prevent accidentally got unwanted entity (eg.: desire to get `company` entity but returned both `company` & `company-staff` entities)
