### PR TITLE
fix mutual state key

### DIFF
--- a/.changeset/smart-phones-ring.md
+++ b/.changeset/smart-phones-ring.md
@@ -1,0 +1,5 @@
+---
+"@monorise/react": patch
+---
+
+fix mutual state key

--- a/packages/react/actions/core.action.ts
+++ b/packages/react/actions/core.action.ts
@@ -375,7 +375,7 @@ const initCoreActions = (
       defaultMutualData?: Record<string, any>;
     } = {},
   ) => {
-    const selfKey = `${byEntityType}/${byEntityId}/${entityType}`;
+    const selfKey = `${byEntityType}/${entityType}/${byEntityId}/list`;
     const mutualService = makeMutualService(byEntityType, entityType);
     const store = monoriseStore.getState();
     const mutualState = store.mutual[selfKey] || {};
@@ -461,8 +461,8 @@ const initCoreActions = (
 
     monoriseStore.setState(
       produce((state) => {
-        const bySide = `${byEntityType}/${byEntityId}/${entityType}`;
-        const side = `${entityType}/${entityId}/${byEntityType}`;
+        const bySide = `${byEntityType}/${entityType}/${byEntityId}/list`;
+        const side = `${entityType}/${byEntityType}/${entityId}/list`;
 
         if (!state.mutual[bySide]) {
           state.mutual[bySide] = {
@@ -509,8 +509,8 @@ const initCoreActions = (
 
     monoriseStore.setState(
       produce((state) => {
-        const bySide = `${byEntityType}/${byEntityId}/${entityType}`;
-        const side = `${entityType}/${entityId}/${byEntityType}`;
+        const bySide = `${byEntityType}/${entityType}/${byEntityId}/list`;
+        const side = `${entityType}/${byEntityType}/${entityId}/list`;
 
         if (!state.mutual[bySide]) {
           state.mutual[bySide] = {
@@ -573,8 +573,8 @@ const initCoreActions = (
 
     monoriseStore.setState(
       produce((state) => {
-        const bySide = `${byEntityType}/${byEntityId}/${entityType}`;
-        const side = `${entityType}/${entityId}/${byEntityType}`;
+        const bySide = `${byEntityType}/${entityType}/${byEntityId}/list`;
+        const side = `${entityType}/${byEntityType}/${entityId}/list`;
 
         if (!state.mutual[bySide]) {
           state.mutual[bySide] = {
@@ -620,8 +620,8 @@ const initCoreActions = (
 
     monoriseStore.setState(
       produce((state) => {
-        const bySide = `${byEntityType}/${byEntityId}/${entityType}`;
-        const side = `${entityType}/${entityId}/${byEntityType}`;
+        const bySide = `${byEntityType}/${entityType}/${byEntityId}/list`;
+        const side = `${entityType}/${byEntityType}/${entityId}/list`;
 
         if (!state.mutual[bySide]) {
           state.mutual[bySide] = {
@@ -665,8 +665,8 @@ const initCoreActions = (
 
     monoriseStore.setState(
       produce((state) => {
-        const bySide = `${byEntityType}/${byEntityId}/${entityType}`;
-        const side = `${entityType}/${entityId}/${byEntityType}`;
+        const bySide = `${byEntityType}/${entityType}/${byEntityId}/list`;
+        const side = `${entityType}/${byEntityType}/${entityId}/list`;
 
         state.mutual[bySide].dataMap.delete(data.entityId);
 
@@ -687,8 +687,8 @@ const initCoreActions = (
   ) => {
     monoriseStore.setState(
       produce((state) => {
-        const bySide = `${byEntityType}/${byEntityId}/${entityType}`;
-        const side = `${entityType}/${entityId}/${byEntityType}`;
+        const bySide = `${byEntityType}/${entityType}/${byEntityId}/list`;
+        const side = `${entityType}/${byEntityType}/${entityId}/list`;
         const bySideDataMap = new Map(state[bySide]?.dataMap);
         const sideDataMap = new Map(state[side]?.dataMap);
         bySideDataMap.delete(entityId);

--- a/packages/react/actions/core.action.ts
+++ b/packages/react/actions/core.action.ts
@@ -315,7 +315,8 @@ const initCoreActions = (
     chainEntityQuery?: string,
   ) => {
     const selfKey =
-      opts.stateKey ?? mutualStateKey(byEntityType, id, entityType);
+      opts.stateKey ??
+      mutualStateKey(byEntityType, id, entityType, undefined, chainEntityQuery);
     const mutualService = makeMutualService(byEntityType, entityType);
     const store = monoriseStore.getState();
     const mutualState = store.mutual[selfKey] || {};
@@ -380,7 +381,12 @@ const initCoreActions = (
     const mutualService = makeMutualService(byEntityType, entityType);
     const store = monoriseStore.getState();
     const mutualState = store.mutual[selfKey] || {};
-    const requestKey = `mutual/${selfKey}/${entityId}/get`;
+    const requestKey = `mutual/${mutualStateKey(
+      byEntityType,
+      byEntityId,
+      entityType,
+      entityId,
+    )}/get`;
     const isLoading = checkIsLoading(requestKey);
     const error = getError(requestKey);
 
@@ -439,7 +445,12 @@ const initCoreActions = (
           state.entity[entityType].dataMap = newEntityDataMap;
         }),
         undefined,
-        `mr/mutual/get/${selfKey}/${entityId}`,
+        `mr/mutual/get/${mutualStateKey(
+          byEntityType,
+          byEntityId,
+          entityType,
+          entityId,
+        )}`,
       );
     }
   };
@@ -487,7 +498,7 @@ const initCoreActions = (
         );
       }),
       undefined,
-      `mr/mutual/create/${mutualStateKey(byEntityType, byEntityId, entityType)}/${entityId}`,
+      `mr/mutual/create/${mutualStateKey(byEntityType, byEntityId, entityType, entityId)}`,
     );
   };
 
@@ -535,7 +546,7 @@ const initCoreActions = (
         );
       }),
       undefined,
-      `mr/mutual/create/${mutualStateKey(byEntityType, byEntityId, entityType)}/${entityId}`,
+      `mr/mutual/create/${mutualStateKey(byEntityType, byEntityId, entityType, entityId)}`,
     );
   };
 
@@ -599,7 +610,7 @@ const initCoreActions = (
         );
       }),
       undefined,
-      `mr/mutual/local-update/${mutualStateKey(byEntityType, byEntityId, entityType)}/${entityId}`,
+      `mr/mutual/local-update/${mutualStateKey(byEntityType, byEntityId, entityType, entityId)}`,
     );
   };
 
@@ -646,7 +657,7 @@ const initCoreActions = (
         );
       }),
       undefined,
-      `mr/mutual/edit/${mutualStateKey(byEntityType, byEntityId, entityType)}/${entityId}`,
+      `mr/mutual/edit/${mutualStateKey(byEntityType, byEntityId, entityType, entityId)}`,
     );
   };
 
@@ -676,7 +687,7 @@ const initCoreActions = (
         }
       }),
       undefined,
-      `mr/mutual/delete/${mutualStateKey(byEntityType, byEntityId, entityType)}/${entityId}`,
+      `mr/mutual/delete/${mutualStateKey(byEntityType, byEntityId, entityType, entityId)}`,
     );
   };
 
@@ -699,7 +710,7 @@ const initCoreActions = (
         state.mutual[side].dataMap.delete(byEntityId);
       }),
       undefined,
-      `mr/mutual/local-delete/${mutualStateKey(byEntityType, byEntityId, entityType)}/${entityId}`,
+      `mr/mutual/local-delete/${mutualStateKey(byEntityType, byEntityId, entityType, entityId)}`,
     );
   };
 
@@ -918,7 +929,7 @@ const initCoreActions = (
   } => {
     const stateKey = mutualStateKey(byEntityType, byId, entityType);
     const state = monoriseStore((state) => state.mutual[stateKey]);
-    const requestKey = `mutual/${stateKey}/${id}/get`;
+    const requestKey = `mutual/${mutualStateKey(byEntityType, byId, entityType, id)}/get`;
     const isLoading = useLoadStore(requestKey);
     const error = useErrorStore(requestKey);
 
@@ -960,6 +971,7 @@ const initCoreActions = (
       byEntityType,
       byId || '',
       entityType,
+      undefined,
       chainEntityQuery,
     );
     const state = monoriseStore((state) => state.mutual[stateKey]);

--- a/packages/react/lib/utils.ts
+++ b/packages/react/lib/utils.ts
@@ -1,3 +1,5 @@
+import type { Entity } from '@monorise/base';
+
 export const convertToMap = <T extends Record<string, any>>(
   data: T[],
   mapKey: string,
@@ -9,4 +11,21 @@ export const convertToMap = <T extends Record<string, any>>(
   }
 
   return map;
+};
+
+export const mutualStateKey = (
+  byEntity: Entity,
+  byEntityId: string | null,
+  entity: Entity,
+  chainEntityQuery?: string,
+) => {
+  return `${byEntity}/${byEntityId}/${entity}${chainEntityQuery ? `?${chainEntityQuery}` : ''}`;
+};
+
+export const tagStateKey = (
+  entityType: Entity,
+  tagName: string,
+  group?: string,
+) => {
+  return `${entityType}/${tagName}/${group || ''}`;
 };

--- a/packages/react/lib/utils.ts
+++ b/packages/react/lib/utils.ts
@@ -17,9 +17,10 @@ export const mutualStateKey = (
   byEntity: Entity,
   byEntityId: string | null,
   entity: Entity,
+  entityId?: string,
   chainEntityQuery?: string,
 ) => {
-  return `${byEntity}/${byEntityId}/${entity}${chainEntityQuery ? `?${chainEntityQuery}` : ''}`;
+  return `${byEntity}/${byEntityId}/${entity}${entityId ? `/${entityId}` : ''}${chainEntityQuery ? `?${chainEntityQuery}` : ''}`;
 };
 
 export const tagStateKey = (


### PR DESCRIPTION
## Issue

![image](https://github.com/user-attachments/assets/4a2ceebf-9d7f-4520-86a3-e93334f984a5)
when we are using `useMutuals` to list data, we are listing from state key `job-application/activity/.../list`, however when we `createMutual`, the new mutual data is stored inside state key `job-application/.../activity`, meaning that `useMutuals` hook will not recognize the latest created mutual because it is stored inside a different state key

## Fix

change all mutual related state action to use same state key pattern