### PR TITLE
fix axios interceptor removing all headers

### DIFF
--- a/.changeset/petite-knives-warn.md
+++ b/.changeset/petite-knives-warn.md
@@ -1,0 +1,5 @@
+---
+"@monorise/react": patch
+---
+
+fix axios interceptor removing all headers

--- a/packages/react/lib/api.ts
+++ b/packages/react/lib/api.ts
@@ -40,6 +40,7 @@ const initAxiosInterceptor = (store: MonoriseStore, appActions: AppActions) => {
       url,
       data,
       headers: {
+        ...(config.headers || {}),
         'Mr-Interruptive': String(isInterruptive),
       },
     });

--- a/packages/react/services/filestore.service.ts
+++ b/packages/react/services/filestore.service.ts
@@ -35,7 +35,6 @@ const initFilestoreService = (axios: AxiosInterceptor) => {
         scope,
         directory,
         filename: name,
-        fileType: file.type,
       },
     });
 
@@ -47,6 +46,7 @@ const initFilestoreService = (axios: AxiosInterceptor) => {
       },
       headers: {
         'Content-Type': file.type,
+        'Content-Disposition': 'inline',
       },
       onUploadProgress: (progressEvent) => {
         if (onProgress && progressEvent.total) {


### PR DESCRIPTION
Currently if you do something like 
```
axios.put(data.url, file, {
      requestKey: `filestore/upload/${name}`,
      isInterruptive: !disableLoading,
      feedback: {
        loading: 'Uploading file',
      },
      headers: { // added this
        'Content-Type': file.type,
        'Content-Disposition': 'inline', 
      },
      onUploadProgress: (progressEvent) => {
        if (onProgress && progressEvent.total) {
          const progress = Math.round(
            (progressEvent.loaded / progressEvent.total) * 100,
          );
          onProgress(progress);
        }
      },
    });
    ```
    The entire headers will be removed, this PR put it back in