### PR TITLE
Feat/unique field implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4873,7 +4873,7 @@
     },
     "packages/base": {
       "name": "@monorise/base",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.2"
@@ -4893,7 +4893,7 @@
     },
     "packages/core": {
       "name": "@monorise/core",
-      "version": "0.0.1",
+      "version": "0.0.4",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.758.0",
@@ -4910,13 +4910,13 @@
         "vitest": "^3.1.1"
       },
       "peerDependencies": {
-        "@monorise/base": "^0.0.2",
+        "@monorise/base": "^0.0.3",
         "express": "^4.21.2"
       }
     },
     "packages/react": {
       "name": "@monorise/react",
-      "version": "0.0.3",
+      "version": "0.0.6",
       "license": "ISC",
       "dependencies": {
         "@tabler/icons-react": "^3.30.0",
@@ -4929,7 +4929,7 @@
         "@types/react-dom": "^18"
       },
       "peerDependencies": {
-        "@monorise/base": "^0.0.2",
+        "@monorise/base": "^0.0.3",
         "react": "^18",
         "react-dom": "^18"
       }

--- a/packages/base/types/monorise.type.ts
+++ b/packages/base/types/monorise.type.ts
@@ -61,6 +61,7 @@ export interface MonoriseEntityConfig<
   displayName: string;
 
   /**
+   * @description (DEPRECATED) Use `uniqueFields` instead, Monorise should not handle auth mechanism
    * @description (Optional) Specify the authentication method to be used for the entity
    */
   authMethod?: {

--- a/packages/core/controllers/entity/get-entity-by-unique-field-value.controller.ts
+++ b/packages/core/controllers/entity/get-entity-by-unique-field-value.controller.ts
@@ -1,0 +1,36 @@
+import type { Entity } from '@monorise/base';
+import type { Request, Response } from 'express';
+import httpStatus from 'http-status';
+import type { EntityRepository } from '../../data/Entity';
+
+export class GetEntityByUniqueFieldValueController {
+  constructor(private entityRepository: EntityRepository) {}
+
+  controller: (req: Request, res: Response) => void = async (req, res) => {
+    const { entityType, byUniqueField, byUniqueFieldValue } =
+      req.params as unknown as {
+        entityType: Entity;
+        byUniqueField: string;
+        byUniqueFieldValue: string;
+      };
+
+    try {
+      const entity = await this.entityRepository.getEntityByUniqueField(
+        entityType,
+        byUniqueField,
+        byUniqueFieldValue,
+      );
+
+      return res.status(httpStatus.OK).json(entity);
+    } catch (err) {
+      if ((err as any).code === 'ENTITY_IS_UNDEFINED') {
+        return res.status(httpStatus.NOT_FOUND).json({
+          code: 'ENTITY_NOT_FOUND',
+          message: 'Entity not found',
+        });
+      }
+
+      throw err;
+    }
+  };
+}

--- a/packages/core/controllers/setupRoutes.ts
+++ b/packages/core/controllers/setupRoutes.ts
@@ -49,6 +49,10 @@ const setupCommonRoutes =
       container.createEntityController.controller,
     );
     router.get(
+      '/entity/:entityType/:byUniqueField/:byUniqueFieldValue',
+      container.getEntityByUniqueFieldController.controller,
+    );
+    router.get(
       '/entity/:entityType/:entityId',
       container.getEntityController.controller,
     );

--- a/packages/core/data/Entity.ts
+++ b/packages/core/data/Entity.ts
@@ -268,10 +268,60 @@ export class EntityRepository extends Repository {
     return;
   }
 
+  async getEntityByUniqueField<T extends EntityType>(
+    entityType: T,
+    fieldName: string,
+    value: string,
+  ): Promise<Entity<T>> {
+    const resp = await this.dynamodbClient.query({
+      TableName: this.TABLE_NAME,
+      KeyConditionExpression: '#PK = :PK and begins_with(#SK, :SK)',
+      ExpressionAttributeNames: {
+        '#PK': 'PK',
+        '#SK': 'SK',
+      },
+      ExpressionAttributeValues: {
+        ':PK': { S: `UNIQUE#${fieldName}#${value}` },
+        ':SK': { S: entityType },
+      },
+    });
+
+    return Entity.fromItem(resp.Items?.[0]);
+  }
+
+  async getUniqueFieldValueAvailability<T extends EntityType>(
+    entityType: T,
+    fieldName: string,
+    value: string,
+  ): Promise<void> {
+    const resp = await this.dynamodbClient.query({
+      TableName: this.TABLE_NAME,
+      KeyConditionExpression: '#PK = :PK and begins_with(#SK, :SK)',
+      ExpressionAttributeNames: {
+        '#PK': 'PK',
+        '#SK': 'SK',
+      },
+      ExpressionAttributeValues: {
+        ':PK': { S: `UNIQUE#${fieldName}#${value}` },
+        ':SK': { S: entityType },
+      },
+    });
+
+    if (resp.Items?.[0]) {
+      throw new StandardError(
+        'UNIQUE_VALUE_EXISTS',
+        `${fieldName} '${value}' already exists`,
+      );
+    }
+
+    return;
+  }
+
   createEntityTransactItems<T extends EntityType>(
     entity: Entity<T>,
-    opts?: {
+    opts: {
       mutualId?: string;
+      uniqueFieldValues: Record<string, string>;
     },
   ): TransactWriteItem[] {
     const TransactItems: TransactWriteItem[] = [
@@ -322,6 +372,24 @@ export class EntityRepository extends Repository {
       });
     }
 
+    for (const field in opts.uniqueFieldValues) {
+      TransactItems.push({
+        Put: {
+          TableName: this.TABLE_NAME,
+          ConditionExpression: 'attribute_not_exists(PK)',
+          Item: {
+            ...entity.toItem(),
+            PK: {
+              S: `UNIQUE#${field}#${(entity.data as Record<string, string>)[field]}`,
+            },
+            SK: { S: entity.entityType },
+            R1PK: entity.keys().PK,
+            R1SK: entity.keys().SK,
+          },
+        },
+      });
+    }
+
     return TransactItems;
   }
 
@@ -342,8 +410,47 @@ export class EntityRepository extends Repository {
       currentDatetime,
       currentDatetime,
     );
+
+    const uniqueFields = (this.EntityConfig[entityType].uniqueFields ||
+      []) as string[];
+
+    const hasUniqueFields = Object.keys(entityPayload).some((field) =>
+      uniqueFields.includes(field),
+    );
+
+    let uniqueFieldValues: Record<string, string> = {};
+
+    if (hasUniqueFields) {
+      const uniqueFieldAvailabilityPromises = uniqueFields.map((field) => {
+        if (
+          typeof (entityPayload as Record<string, string>)[field] !== 'string'
+        ) {
+          throw new StandardError(
+            'INVALID_UNIQUE_VALUE_TYPE',
+            `Invalid type. ${field} is not a 'string'.`,
+          );
+        }
+        return this.getUniqueFieldValueAvailability(
+          entityType,
+          field,
+          (entityPayload as Record<string, string>)[field],
+        );
+      });
+
+      await Promise.all(uniqueFieldAvailabilityPromises);
+
+      uniqueFieldValues = uniqueFields.reduce(
+        (acc, field) => ({
+          ...acc,
+          [field]: (entityPayload as Record<string, unknown>)[field],
+        }),
+        {},
+      );
+    }
+
     const TransactItems = this.createEntityTransactItems<T>(entity, {
       mutualId: opts?.mutualId,
+      uniqueFieldValues,
     });
 
     await this.dynamodbClient.transactWriteItems({ TransactItems });
@@ -361,7 +468,7 @@ export class EntityRepository extends Repository {
       entityType,
       entityId,
       data: payload,
-      updatedAt: currentDatetime
+      updatedAt: currentDatetime,
     });
     const params: UpdateItemCommandInput = {
       TableName: this.TABLE_NAME,
@@ -381,6 +488,59 @@ export class EntityRepository extends Repository {
     return updatedEntity;
   }
 
+  updateEntityTransactItems<T extends EntityType>(
+    entity: Entity<T>,
+    updateParams: UpdateItemCommandInput,
+    previousUniqueFieldValues: Record<string, string>,
+    previousEntity: Entity<T>,
+  ) {
+    const transactItems: TransactWriteItem[] = [
+      {
+        Update: {
+          ...updateParams,
+          UpdateExpression: updateParams.UpdateExpression,
+        },
+      },
+    ];
+
+    for (const field in previousUniqueFieldValues) {
+      transactItems.push(
+        {
+          Delete: {
+            TableName: this.TABLE_NAME,
+            Key: {
+              PK: { S: `UNIQUE#${field}#${previousUniqueFieldValues[field]}` },
+              SK: { S: entity.entityType },
+            },
+          },
+        },
+        {
+          Put: {
+            TableName: this.TABLE_NAME,
+            ConditionExpression: 'attribute_not_exists(PK)',
+            Item: {
+              ...entity.toItem(),
+              data: {
+                M: {
+                  ...previousEntity.toItem().data.M,
+                  ...entity.toItem().data.M,
+                },
+              },
+              PK: {
+                S: `UNIQUE#${field}#${(entity.data as Record<string, string>)[field]}`,
+              },
+              SK: { S: entity.entityType },
+              R1PK: entity.keys().PK,
+              R1SK: entity.keys().SK,
+            },
+          },
+        },
+      );
+    }
+
+    return transactItems;
+  }
+
   async updateEntity<T extends EntityType>(
     entityType: T,
     entityId: string,
@@ -389,9 +549,9 @@ export class EntityRepository extends Repository {
       updatedAt?: string;
     },
     opts?: {
-      ConditionExpression: string;
-      ExpressionAttributeNames: Record<string, string>;
-      ExpressionAttributeValues: Record<string, AttributeValue>;
+      ConditionExpression?: string;
+      ExpressionAttributeNames?: Record<string, string>;
+      ExpressionAttributeValues?: Record<string, AttributeValue>;
     },
   ): Promise<Entity<T>> {
     try {
@@ -400,6 +560,7 @@ export class EntityRepository extends Repository {
         updatedAt: currentDatetime,
         ...toUpdate,
       });
+
       const params: UpdateItemCommandInput = {
         TableName: this.TABLE_NAME,
         ReturnValues: 'ALL_NEW',
@@ -416,6 +577,72 @@ export class EntityRepository extends Repository {
           ...opts?.ExpressionAttributeValues,
         },
       };
+
+      const entity = new Entity(entityType, entityId, toUpdate.data);
+
+      const uniqueFields = (this.EntityConfig[entityType].uniqueFields ||
+        []) as string[];
+
+      const hasUniqueFields = Object.keys(toUpdate.data).some((field) =>
+        uniqueFields.includes(field),
+      );
+
+      let updatedUniqueFields: string[] = [];
+      let previousUniqueFieldValues: Record<string, string> = {};
+      let previousEntity: Entity<T>;
+
+      if (hasUniqueFields) {
+        previousEntity = await this.getEntity(entityType, entityId);
+
+        // check if any of the unique fields has changed
+        updatedUniqueFields = uniqueFields.filter(
+          (field) =>
+            (toUpdate.data as Record<string, unknown>)[field] !==
+            (previousEntity.data as Record<string, unknown>)[field],
+        );
+
+        previousUniqueFieldValues = updatedUniqueFields.reduce(
+          (acc, field) => ({
+            ...acc,
+            [field]: (previousEntity.data as Record<string, unknown>)[field],
+          }),
+          {},
+        );
+
+        const uniqueFieldAvailabilityPromises = Object.keys(
+          previousUniqueFieldValues,
+        ).map((field) => {
+          if (
+            typeof (toUpdate.data as Record<string, unknown>)[field] !==
+            'string'
+          ) {
+            throw new StandardError(
+              'INVALID_UNIQUE_VALUE_TYPE',
+              `Invalid type. ${field} is not a 'string'.`,
+            );
+          }
+          return this.getUniqueFieldValueAvailability(
+            entityType,
+            field,
+            (toUpdate.data as Record<string, string>)[field],
+          );
+        });
+
+        await Promise.all(uniqueFieldAvailabilityPromises);
+
+        if (updatedUniqueFields.length > 0) {
+          const TransactItems = this.updateEntityTransactItems(
+            entity,
+            params,
+            previousUniqueFieldValues,
+            previousEntity,
+          );
+
+          await this.dynamodbClient.transactWriteItems({ TransactItems });
+
+          return await this.getEntity(entityType, entityId);
+        }
+      }
 
       const resp = await this.dynamodbClient.updateItem(params);
       const updatedEntity = Entity.fromItem<T>(resp.Attributes);

--- a/packages/core/data/__tests__/Entity.test.ts
+++ b/packages/core/data/__tests__/Entity.test.ts
@@ -58,11 +58,14 @@ const mockEntityConfig = {
         newField: z.string(), // Added from upsert test
         city: z.string(), // Added from queryEntities test
         age: z.number(), // Added from Entity class test
+        username: z.string(),
       })
       .partial(),
     createSchema: z.object({
       name: z.string(),
+      username: z.string(),
     }),
+    uniqueFields: ['username'],
     searchableFields: ['name', 'email'],
     authMethod: { email: { tokenExpiresIn: 3600000 } }, // Define authMethod for USER
   }),
@@ -269,11 +272,14 @@ describe('Entity & EntityRepository', () => {
   describe('EntityRepository', () => {
     // Use MockEntityType enum
     let createdUser: Entity<EntityType>;
+    let updatedUser: Entity<EntityType>;
     const userEmail = `test-${ulid()}@example.com`;
+    const username = `test-${ulid()}`;
     const userData = {
       name: 'Repo Test User',
       email: userEmail,
       role: 'admin',
+      username: username,
     };
 
     it('should create an entity successfully', async () => {
@@ -281,6 +287,10 @@ describe('Entity & EntityRepository', () => {
       createdUser = await entityRepository.createEntity(
         MockEntityType.USER as unknown as EntityType,
         userData,
+        undefined,
+        {
+          uniqueFields: ['username'],
+        },
       );
 
       expect(createdUser).toBeInstanceOf(Entity);
@@ -388,9 +398,41 @@ describe('Entity & EntityRepository', () => {
       ).rejects.toThrow('Email already exists');
     });
 
-    it('should update an entity', async () => {
+    it('should get an entity by unique field', async () => {
+      const fetched = await entityRepository.getEntityByUniqueField(
+        MockEntityType.USER as unknown as EntityType,
+        'username',
+        username,
+      );
+
+      expect(fetched.entityId).toEqual(createdUser.entityId);
+      expect(fetched.data).toEqual(userData);
+    });
+
+    it('should confirm unique field availability for an unused unique field value', async () => {
+      await expect(
+        entityRepository.getUniqueFieldValueAvailability(
+          MockEntityType.USER as unknown as EntityType,
+          'username',
+          'unused-username',
+        ),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should throw when checking unique field value for a used value', async () => {
+      await expect(
+        entityRepository.getUniqueFieldValueAvailability(
+          MockEntityType.USER as unknown as EntityType,
+          'username',
+          username,
+        ),
+      ).rejects.toThrow(`username '${username}' already exists`);
+    });
+
+    it('should update an entity with unique fields', async () => {
       const updatedName = 'Repo Test User Updated';
-      const updatedData = { name: updatedName };
+      const updatedUsername = 'updated-username';
+      const updatedData = { name: updatedName, username: updatedUsername };
       const originalUpdatedAt = createdUser.updatedAt;
 
       // Need a small delay to ensure updatedAt changes
@@ -399,13 +441,14 @@ describe('Entity & EntityRepository', () => {
       // Use MockEntityType enum
       const updatedEntity = await entityRepository.updateEntity(
         MockEntityType.USER as unknown as EntityType,
-        createdUser.entityId!,
+        createdUser.entityId as string,
         { data: updatedData },
       );
 
       expect(updatedEntity.entityId).toEqual(createdUser.entityId);
       expect(updatedEntity.data.name).toEqual(updatedName);
       expect(updatedEntity.data.email).toEqual(userEmail); // Email should remain unchanged
+      expect(updatedEntity.data.username).toEqual(updatedUsername);
       expect(updatedEntity.updatedAt).toBeDefined();
       expect(updatedEntity.updatedAt).not.toEqual(originalUpdatedAt);
       expect(updatedEntity.createdAt).toEqual(createdUser.createdAt); // CreatedAt should not change
@@ -414,7 +457,7 @@ describe('Entity & EntityRepository', () => {
       // Use MockEntityType enum
       const fetched = await entityRepository.getEntity(
         MockEntityType.USER as unknown as EntityType,
-        createdUser.entityId!,
+        createdUser.entityId as string,
       );
       expect(fetched.data.name).toEqual(updatedName);
       expect(fetched.updatedAt).toEqual(updatedEntity.updatedAt);
@@ -431,6 +474,110 @@ describe('Entity & EntityRepository', () => {
           },
         ),
       ).rejects.toThrow('Entity not found');
+    });
+
+    it('should get an entity by updated unique field', async () => {
+      const fetched = await entityRepository.getEntityByUniqueField(
+        MockEntityType.USER as unknown as EntityType,
+        'username',
+        'updated-username',
+      );
+
+      expect(fetched.entityId).toEqual(createdUser.entityId);
+      expect(fetched.data).toEqual({
+        ...userData,
+        username: 'updated-username',
+        name: 'Repo Test User Updated',
+      });
+    });
+
+    it('should confirm unique field availability for an previous unique field value', async () => {
+      await expect(
+        entityRepository.getUniqueFieldValueAvailability(
+          MockEntityType.USER as unknown as EntityType,
+          'username',
+          username,
+        ),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should throw when checking unique field value for a used value (updated)', async () => {
+      await expect(
+        entityRepository.getUniqueFieldValueAvailability(
+          MockEntityType.USER as unknown as EntityType,
+          'username',
+          'updated-username',
+        ),
+      ).rejects.toThrow(`username 'updated-username' already exists`);
+    });
+
+    it('should update an entity without changing unique fields', async () => {
+      const updatedAge = 99;
+      const updatedData = { age: updatedAge };
+      const originalUpdatedAt = createdUser.updatedAt;
+
+      // Need a small delay to ensure updatedAt changes
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Use MockEntityType enum
+      const updatedEntity = await entityRepository.updateEntity(
+        MockEntityType.USER as unknown as EntityType,
+        createdUser.entityId as string,
+        { data: updatedData },
+      );
+
+      expect(updatedEntity.entityId).toEqual(createdUser.entityId);
+      expect(updatedEntity.data.name).toEqual('Repo Test User Updated');
+      expect(updatedEntity.data.email).toEqual(userEmail); // Email should remain unchanged
+      expect(updatedEntity.data.username).toEqual('updated-username');
+      expect(updatedEntity.data.age).toEqual(updatedAge);
+      expect(updatedEntity.updatedAt).toBeDefined();
+      expect(updatedEntity.updatedAt).not.toEqual(originalUpdatedAt);
+      expect(updatedEntity.createdAt).toEqual(createdUser.createdAt); // CreatedAt should not change
+
+      // Verify directly
+      // Use MockEntityType enum
+      const fetched = await entityRepository.getEntity(
+        MockEntityType.USER as unknown as EntityType,
+        createdUser.entityId as string,
+      );
+      expect(fetched.data.age).toEqual(updatedAge);
+      expect(fetched.updatedAt).toEqual(updatedEntity.updatedAt);
+    });
+
+    it('should get an entity by updated unique field', async () => {
+      const fetched = await entityRepository.getEntityByUniqueField(
+        MockEntityType.USER as unknown as EntityType,
+        'username',
+        'updated-username',
+      );
+
+      expect(fetched.entityId).toEqual(createdUser.entityId);
+      expect(fetched.data).toEqual({
+        ...userData,
+        username: 'updated-username',
+        name: 'Repo Test User Updated',
+      });
+    });
+
+    it('should confirm unique field availability for an previous unique field value', async () => {
+      await expect(
+        entityRepository.getUniqueFieldValueAvailability(
+          MockEntityType.USER as unknown as EntityType,
+          'username',
+          username,
+        ),
+      ).resolves.toBeUndefined();
+    });
+
+    it('should throw when checking unique field value for a used value (updated)', async () => {
+      await expect(
+        entityRepository.getUniqueFieldValueAvailability(
+          MockEntityType.USER as unknown as EntityType,
+          'username',
+          'updated-username',
+        ),
+      ).rejects.toThrow(`username 'updated-username' already exists`);
     });
 
     it('should upsert an entity (update existing)', async () => {

--- a/packages/core/mock/monorise/admin.ts
+++ b/packages/core/mock/monorise/admin.ts
@@ -5,12 +5,14 @@ const baseSchema = z
   .object({
     email: z.string().toLowerCase(),
     displayName: z.string(),
+    username: z.string(),
   })
   .partial();
 
 const createSchema = baseSchema.extend({
   email: z.string().toLowerCase(),
   displayName: z.string().min(1, 'Please provide a name for this user account'),
+  username: z.string().min(1, 'Please provide a username for this account'),
 });
 
 const config = createEntityConfig({
@@ -23,6 +25,7 @@ const config = createEntityConfig({
   },
   baseSchema,
   createSchema,
+  uniqueFields: ['username'],
   searchableFields: ['email', 'displayName'],
 });
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,9 +9,7 @@
     "build": "tsc -b",
     "test": "vitest run"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/packages/core/services/DependencyContainer.ts
+++ b/packages/core/services/DependencyContainer.ts
@@ -16,6 +16,7 @@ import { TagRepository } from '../data/Tag';
 import { CreateEntityController } from '../controllers/entity/create-entity.controller';
 import { DeleteEntityController } from '../controllers/entity/delete-entity.controller';
 import { GetEntityController } from '../controllers/entity/get-entity.controller';
+import { GetEntityByUniqueFieldValueController } from '../controllers/entity/get-entity-by-unique-field-value.controller';
 import { ListEntitiesController } from '../controllers/entity/list-entities.controller';
 import { UpdateEntityController } from '../controllers/entity/update-entity.controller';
 import { UpsertEntityController } from '../controllers/entity/upsert-entity.controller';
@@ -154,6 +155,13 @@ export class DependencyContainer {
   get getEntityController(): GetEntityController {
     return this.createCachedInstance(
       GetEntityController,
+      this.entityRepository,
+    );
+  }
+
+  get getEntityByUniqueFieldController(): GetEntityByUniqueFieldValueController {
+    return this.createCachedInstance(
+      GetEntityByUniqueFieldValueController,
       this.entityRepository,
     );
   }


### PR DESCRIPTION
## What

Introduction usage of `uniqueFields`.

### Behaviour

- If `uniqueFields` is specified, entity creation and updates will include a check to ensure that all values of the listed fields are unique within the scope of that entity type.
- If value already exists, creation/updates would throw validation error, eg. `username 'johndoe' already exists`.
- Unique value can also serve as a entry point to retrieve entity, `getEntityByUniqueField(Entity.User, 'username', 'johndoe')`
- On entity deletion, any associated unique field values will be released, making them available for reuse.

## Why

Scalable and flexible way of handling unique values for an entity type such as email, username, identity number etc.