### PR TITLE
fix: @monorise/core export issue

### DIFF
--- a/.changeset/chilly-kids-know.md
+++ b/.changeset/chilly-kids-know.md
@@ -1,0 +1,5 @@
+---
+"@monorise/core": patch
+---
+
+fix: @monorise/core export issue

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -110,5 +110,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "exclude": ["./**/__tests__/**/*"]
+  "exclude": ["./**/__tests__/**/*", "./packages/core/helpers/test/*"]
 }


### PR DESCRIPTION
# problem
![image](https://github.com/user-attachments/assets/5f58f696-b742-4fac-82d8-bad552bf3ce6)

# why
- due to compilation of unnecessary test-util.ts which has dependency on `../../../base` will bring in `base` folder