### PR TITLE
set target to es2016

### DIFF
--- a/.changeset/real-poems-cough.md
+++ b/.changeset/real-poems-cough.md
@@ -1,0 +1,5 @@
+---
+"@monorise/core": patch
+---
+
+Change core package transpile target

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -12,7 +12,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "esnext" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "libReplacement": true,                           /* Enable lib replacement. */


### PR DESCRIPTION
## What

Set core package tsconfig target to `es2016` to fix the following error

<img width="795" alt="image" src="https://github.com/user-attachments/assets/2f67099b-d7ca-4532-adbf-fbdbcfb695f5" />
