### PR TITLE
fix: handle unique field transaction error

### DIFF
--- a/.changeset/tangy-plums-wash.md
+++ b/.changeset/tangy-plums-wash.md
@@ -1,0 +1,5 @@
+---
+"@monorise/core": patch
+---
+
+handle unique field transaction error

--- a/packages/core/controllers/entity/create-entity.controller.ts
+++ b/packages/core/controllers/entity/create-entity.controller.ts
@@ -40,6 +40,12 @@ export class CreateEntityController {
         });
       }
 
+      if (err instanceof StandardError && err.code === 'UNIQUE_VALUE_EXISTS') {
+        return res.status(httpStatus.BAD_REQUEST).json({
+          ...err.toJSON(),
+        });
+      }
+
       console.log('===create-entity error:', {
         err,
         errorContext: JSON.stringify({ body: req.body, headers: req.headers }),

--- a/packages/core/controllers/entity/update-entity.controller.ts
+++ b/packages/core/controllers/entity/update-entity.controller.ts
@@ -45,6 +45,12 @@ export class UpdateEntityController {
         });
       }
 
+      if (err instanceof StandardError && err.code === 'UNIQUE_VALUE_EXISTS') {
+        return res.status(httpStatus.BAD_REQUEST).json({
+          ...err.toJSON(),
+        });
+      }
+
       console.log(
         '====UPDATE_ENTITY_CONTROLLER_ERROR',
         err,


### PR DESCRIPTION
## Issue
- currently unique field will throw general transaction error like below when fail to write 
  ![image](https://github.com/user-attachments/assets/29afd72c-d4ba-4212-8d75-8a16eb0a3222)

## Fix
- handle transaction error caused by unique field and throw `UNIQUE_VALUE_EXISTS` accordingly