### PR TITLE
fix: sudden not working release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,6 @@ jobs:
   release:
     name: Version Bump & Create Release PR
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
# what
- release workflow not triggering after we merged changeset versioning PR into `main`