### PR TITLE
feat: custom reqKey and expose getEntity

### DIFF
--- a/.changeset/afraid-wings-allow.md
+++ b/.changeset/afraid-wings-allow.md
@@ -1,0 +1,9 @@
+---
+"@monorise/react": patch
+---
+
+Update:
+
+- createEntity accepting custom `requestKey`
+  - in some cases, we need to perform bulk create, where multiple requests are deduped
+- expose `getEntity` from core.action

--- a/packages/react/actions/core.action.ts
+++ b/packages/react/actions/core.action.ts
@@ -1258,6 +1258,7 @@ const initCoreActions = (
     listMoreEntities,
     createEntity,
     upsertEntity,
+    getEntity,
     editEntity,
     deleteEntity,
     getMutual,

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -144,6 +144,7 @@ const {
   useMutuals,
   useTaggedEntities,
   useEntityState,
+  getEntity,
 } = Monorise;
 
 export {
@@ -196,6 +197,7 @@ export {
   getMutualRequestKey,
   getTagRequestKey,
   getUniqueFieldRequestKey,
+  getEntity,
 };
 
 export default Monorise;

--- a/packages/react/services/core.service.ts
+++ b/packages/react/services/core.service.ts
@@ -164,7 +164,7 @@ const initCoreService = (
       opts.customUrl || `${entityApiBaseUrl}/${entityType}`,
       values,
       {
-        requestKey: getEntityRequestKey('create', entityType),
+        requestKey: opts.requestKey || getEntityRequestKey('create', entityType),
         isInterruptive: opts.isInterruptive ?? true,
         feedback: {
           loading: `Creating ${entityConfig[entityType].displayName}`,


### PR DESCRIPTION
- createEntity accepting custom `requestKey`
  - in some cases, we need to perform bulk create, where multiple requests are deduped
- expose `getEntity` from core.action