### PR TITLE
feat(cli): add dev mode

### DIFF
--- a/.changeset/olive-trees-create.md
+++ b/.changeset/olive-trees-create.md
@@ -1,0 +1,5 @@
+---
+"@monorise/cli": patch
+---
+
+add cli dev mode

--- a/.changeset/olive-trees-create.md
+++ b/.changeset/olive-trees-create.md
@@ -1,5 +1,5 @@
 ---
-"@monorise/cli": patch
+"@monorise/cli": minor
 ---
 
 add cli dev mode

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,4 +71,6 @@ jobs:
         run: npm ci
 
       - name: Build package
-        run: npm run build
+        run: |
+          npm run build
+          chmod +x packages/cli/dist/cli.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -3173,6 +3173,21 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
@@ -4731,6 +4746,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
@@ -5868,6 +5896,7 @@
       "version": "0.0.2",
       "license": "ISC",
       "dependencies": {
+        "chokidar": "^4.0.3",
         "tsconfig-paths": "^4.2.0",
         "tsx": "^4.19.3"
       },
@@ -5877,7 +5906,7 @@
     },
     "packages/core": {
       "name": "@monorise/core",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.758.0",
@@ -5900,7 +5929,7 @@
     },
     "packages/react": {
       "name": "@monorise/react",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "license": "ISC",
       "dependencies": {
         "@tabler/icons-react": "^3.30.0",

--- a/packages/cli/cli.ts
+++ b/packages/cli/cli.ts
@@ -4,9 +4,21 @@ import 'tsx';
 import 'tsconfig-paths/register.js';
 import fs from 'node:fs';
 import path from 'node:path';
+import { spawn } from 'node:child_process';
+import chokidar from 'chokidar';
 
-async function main() {
-  // Check for monorise.config.ts or monorise.config.js
+function kebabToCamel(str: string): string {
+  return str.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+}
+
+function kebabToPascal(kebab: string): string {
+  return kebab
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join('');
+}
+
+async function generateConfig(): Promise<string> {
   const configFilePathTS = path.resolve('./monorise.config.ts');
   const configFilePathJS = path.resolve('./monorise.config.js');
 
@@ -157,20 +169,120 @@ declare module '@monorise/base' {
 
   fs.writeFileSync(configOutputPath, outputContent);
   console.log('Successfully generated entity configurations and enum!');
+  return configDir;
 }
 
-function kebabToCamel(str: string): string {
-  return str.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
-}
+async function main() {
+  const args = process.argv.slice(2);
+  const command = args[0];
 
-function kebabToPascal(kebab: string): string {
-  return kebab
-    .split('-')
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join('');
+  if (command === 'dev') {
+    let configDir: string | undefined;
+    try {
+      configDir = await generateConfig();
+    } catch (err) {
+      console.error('Generation failed:', err);
+      process.exit(1);
+    }
+
+    if (configDir) {
+      console.log(`Watching for changes in ${configDir}...`);
+      const watcher = chokidar.watch(configDir, {
+        ignored: (watchedPath: string) => {
+          const fileName = path.basename(watchedPath);
+          return (
+            fileName === 'index.ts' ||
+            fileName.startsWith('.') ||
+            watchedPath.endsWith('.js') ||
+            watchedPath.endsWith('.jsx') ||
+            watchedPath.endsWith('.d.ts')
+          );
+        },
+        persistent: true,
+        ignoreInitial: true,
+      });
+
+      let sstDevProcess: ReturnType<typeof spawn> | null = null;
+
+      const runSSTDev = () => {
+        if (sstDevProcess) {
+          console.log('Terminating existing sst dev process...');
+          sstDevProcess.kill('SIGTERM');
+          sstDevProcess = null;
+        }
+        console.log('Starting sst dev...');
+        sstDevProcess = spawn('npx', ['sst', 'dev'], { stdio: 'inherit' });
+        sstDevProcess.on('close', (code) => {
+          console.log(`sst dev process exited with code ${code}`);
+          sstDevProcess = null;
+        });
+        sstDevProcess.on('error', (err) => {
+          console.error('Failed to start sst dev process:', err);
+          sstDevProcess = null;
+        });
+      };
+
+      watcher.on('add', async (filePath) => {
+        console.log(`File ${filePath} has been added. Regenerating...`);
+        try {
+          await generateConfig();
+        } catch (err) {
+          console.error('Regeneration failed:', err);
+        }
+      });
+
+      watcher.on('change', async (filePath) => {
+        console.log(`File ${filePath} has been changed. Regenerating...`);
+        try {
+          await generateConfig();
+        } catch (err) {
+          console.error('Regeneration failed:', err);
+        }
+      });
+
+      watcher.on('unlink', async (filePath) => {
+        console.log(`File ${filePath} has been removed. Regenerating...`);
+        try {
+          await generateConfig();
+        } catch (err) {
+          console.error('Regeneration failed:', err);
+        }
+      });
+
+      // sst dev is started only once, after initial generation
+      runSSTDev();
+
+      process.on('SIGINT', () => {
+        console.log('Monorise dev terminated. Closing watcher and sst dev...');
+        watcher.close();
+        if (sstDevProcess) {
+          sstDevProcess.kill('SIGTERM');
+        }
+        process.exit(0);
+      });
+      process.on('SIGTERM', () => {
+        console.log('Monorise dev terminated. Closing watcher and sst dev...');
+        watcher.close();
+        if (sstDevProcess) {
+          sstDevProcess.kill('SIGTERM');
+        }
+        process.exit(0);
+      });
+    }
+  } else if (command === 'build') {
+    try {
+      await generateConfig();
+    } catch (err) {
+      console.error('Build generation failed:', err);
+      process.exit(1);
+    }
+  } else {
+    console.error('Unknown command. Usage: monorise [dev|build]');
+    process.exit(1);
+  }
 }
 
 main().catch((err) => {
-  console.error('Generation failed:', err);
+  console.error('Monorise encountered an unhandled error:', err);
   process.exit(1);
 });

--- a/packages/cli/cli.ts
+++ b/packages/cli/cli.ts
@@ -272,8 +272,31 @@ async function main() {
   } else if (command === 'build') {
     try {
       await generateConfig();
+
+      // Run sst build after generating files
+      console.log('Starting sst build...');
+      const sstBuildProcess = spawn('npx', ['sst', 'build'], {
+        stdio: 'inherit',
+      });
+
+      // Wait for sst build to complete
+      await new Promise<void>((resolve, reject) => {
+        sstBuildProcess.on('close', (code) => {
+          if (code === 0) {
+            console.log('sst build completed successfully.');
+            resolve();
+          } else {
+            reject(new Error(`sst build exited with code ${code}.`));
+          }
+        });
+        sstBuildProcess.on('error', (err) => {
+          reject(
+            new Error(`Failed to start sst build process: ${err.message}.`),
+          );
+        });
+      });
     } catch (err) {
-      console.error('Build generation failed:', err);
+      console.error('Build process failed:', err);
       process.exit(1);
     }
   } else {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,6 +16,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "chokidar": "^4.0.3",
     "tsconfig-paths": "^4.2.0",
     "tsx": "^4.19.3"
   },


### PR DESCRIPTION
## What 

- Add cli to enable dev mode
- removed `monorise` command, instead broken down into 2 different commands

Currently there are 2 different commands:
- `monorise dev`: Generate monorise index file, and start `sst dev`, at the same time also watch changes in the monorise config directory
- `monorise build`: Just generate monorise index file

## Why

Improve developer experience. Developer doesn't need to know when to run the `monorise` script again. Any changes in entity config would automatically updated during local dev mode.

## How to implement

In your `package.json`,  instead of this
```
{
  // ...
  "scripts": {
    "dev": "sst dev"
    "build": "sst build"
  }
}
```
now you could do this:
```
{
  // ...
  "scripts": {
    "dev": "monorise dev"
    "build": "monorise build"
  }
}
```