### PR TITLE
Upgrade zod to v4

### DIFF
--- a/.changeset/legal-areas-sell.md
+++ b/.changeset/legal-areas-sell.md
@@ -1,0 +1,5 @@
+---
+"@monorise/base": minor
+---
+
+Upgrade zod to v4, retire `effects` field since we can merge refined shapes, improves usability of `createEntityConfig`

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -2,6 +2,7 @@
   "name": "@monorise/base",
   "version": "0.0.4",
   "description": "",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "directories": {
@@ -15,9 +16,7 @@
   "author": "",
   "license": "ISC",
   "peerDependencies": {
-    "zod": "^3.24.2"
+    "zod": "^3.25.53"
   },
-  "files": [
-    "dist"
-  ]
+  "files": ["dist"]
 }

--- a/packages/base/types/monorise.type.ts
+++ b/packages/base/types/monorise.type.ts
@@ -1,4 +1,4 @@
-import type { z } from 'zod';
+import type { z } from 'zod/v4';
 
 export enum Entity {}
 
@@ -42,9 +42,15 @@ export type CreatedEntity<T extends Entity = Entity> = {
  */
 export interface MonoriseEntityConfig<
   T extends Entity = Entity,
-  B extends z.ZodRawShape = z.ZodRawShape,
-  C extends z.ZodRawShape = z.ZodRawShape,
-  M extends z.ZodRawShape = z.ZodRawShape,
+  B extends Partial<Record<never, z.core.SomeType>> = Partial<
+    Record<never, z.core.SomeType>
+  >,
+  C extends Partial<Record<never, z.core.SomeType>> = Partial<
+    Record<never, z.core.SomeType>
+  >,
+  M extends Partial<Record<never, z.core.SomeType>> = Partial<
+    Record<never, z.core.SomeType>
+  >,
   CO extends z.ZodObject<C> | undefined = undefined,
   MO extends z.ZodObject<M> | undefined = undefined,
 > {
@@ -149,23 +155,6 @@ export interface MonoriseEntityConfig<
       }[];
     }[];
   };
-  /**
-   * Use this function to perform side effects on the final schema for example refine/superRefine the schema
-   *
-   * @param schema The final schema of the entity (the combination of `baseSchema`/`createSchema` and `mutualSchema` if specified)
-   * @returns void
-   *
-   * @example
-   * ```ts
-   * effect: (schema) => {
-   *   schema.refine(
-   *     // refinement logic here
-   *   )
-   * }
-   */
-  effect?: (
-    schema: z.ZodObject<z.ZodRawShape>,
-  ) => z.ZodEffects<z.ZodObject<z.ZodRawShape>>;
 
   /**
    * @description (Optional) Use tags to create additional access patterns for the entity.

--- a/packages/base/utils/index.ts
+++ b/packages/base/utils/index.ts
@@ -1,45 +1,33 @@
-import type { Entity, MonoriseEntityConfig } from '@monorise/base';
-import { z } from 'zod';
+import type { Entity, MonoriseEntityConfig } from '../types/monorise.type';
+import { z } from 'zod/v4';
 
 function makeSchema<
   T extends Entity,
-  B extends z.ZodRawShape,
-  C extends z.ZodRawShape,
-  M extends z.ZodRawShape,
-  CO extends z.ZodObject<C> | undefined = undefined,
-  MO extends z.ZodObject<M> | undefined = undefined,
+  B extends Partial<Record<never, z.core.SomeType>>,
+  C extends Partial<Record<never, z.core.SomeType>>,
+  M extends Partial<Record<never, z.core.SomeType>>,
+  CO extends z.ZodObject<C> | undefined,
+  MO extends z.ZodObject<M> | undefined,
 >(config: MonoriseEntityConfig<T, B, C, M, CO, MO>) {
-  const { baseSchema, createSchema, mutual, effect } = config;
+  const { baseSchema, createSchema, mutual } = config;
   const { mutualSchema } = mutual || {};
-
-  type FinalSchemaType = CO extends z.AnyZodObject
-    ? MO extends z.AnyZodObject
-      ? z.ZodObject<MO['shape'] & CO['shape']>
-      : CO
-    : MO extends z.AnyZodObject
-      ? z.ZodObject<MO['shape'] & B>
-      : z.ZodObject<B>;
 
   const finalSchema = z.object({
     ...baseSchema.shape,
     ...createSchema?.shape,
     ...mutualSchema?.shape,
-  }) as FinalSchemaType;
-
-  if (effect) {
-    return effect(finalSchema) as z.ZodEffects<FinalSchemaType>;
-  }
+  });
 
   return finalSchema;
 }
 
 const createEntityConfig = <
   T extends Entity,
-  B extends z.ZodRawShape,
-  C extends z.ZodRawShape,
-  M extends z.ZodRawShape,
-  CO extends z.ZodObject<C> | undefined = undefined,
-  MO extends z.ZodObject<M> | undefined = undefined,
+  B extends Partial<Record<never, z.core.SomeType>>,
+  C extends Partial<Record<never, z.core.SomeType>>,
+  M extends Partial<Record<never, z.core.SomeType>>,
+  CO extends z.ZodObject<C> | undefined,
+  MO extends z.ZodObject<M> | undefined,
 >(
   config: MonoriseEntityConfig<T, B, C, M, CO, MO>,
 ) => ({


### PR DESCRIPTION
## What

- Bump zod to v4 (major version)
- Simplifies `createEntityConfig`, we could remove `effects` field entirely
- All schemas, `baseSchema`, `createSchema` and `mutualSchema` supports refine.

## Why
- Major performance upgrade especially when resolving types, [almost x100 faster
](https://zod.dev/v4?id=100x-reduction-in-tsc-instantiations)
## Note
Zod 3.25.0 onwards include v4 codes, there isn't an actual v4 package yet but this could help [transition to the actual v4](https://zod.dev/v4?id=versioning) package easily

## How to use

With `effects` gone, how can we refine schema? Here's a simple example, simple enough?

```js
import { createEntityConfig } from '@monorise/base';
import { z } from 'zod/v4';

const baseSchema = z
  .object({
    name: z.string(),
    age: z.number(),
  })
  .refine(
    (value) => {
      if (value.age < 16) {
        return false;
      }

      return true;
    },
    {
      message:
        'Must be at least 16 years old',
      path: ['options'],
    },
  );

const config = createEntityConfig({
  name: 'user',
  displayName: 'User',
  baseSchema,
  searchableFields: ['name'],
});

export default config;
```
