### PR TITLE
fix(react): get mutual action shouldn't throw error

### DIFF
--- a/packages/react/actions/core.action.ts
+++ b/packages/react/actions/core.action.ts
@@ -487,7 +487,7 @@ const initCoreActions = (
       ));
     } catch (err) {
       if (!opts.defaultMutualData) {
-        throw err;
+        return;
       }
 
       hasRequestFailed = true;


### PR DESCRIPTION
## What

`getMutual` action in react package shouldn't throw error but return instead.