### PR TITLE
fix: package consumer resolving types indefinitely

### DIFF
--- a/.changeset/clean-eagles-relax.md
+++ b/.changeset/clean-eagles-relax.md
@@ -1,0 +1,5 @@
+---
+"@monorise/base": patch
+---
+
+Fix @monorise/base import relatively instead of recursively

--- a/packages/base/utils/index.ts
+++ b/packages/base/utils/index.ts
@@ -1,4 +1,4 @@
-import type { Entity, MonoriseEntityConfig } from '@monorise/base';
+import type { Entity, MonoriseEntityConfig } from '../types/monorise.type';
 import { z } from 'zod';
 
 function makeSchema<


### PR DESCRIPTION
## What

Consumer package occasionally not able to resolve monorise entity types indefinitely, and also cause high memory usage in code editor. Not sure if this is the root cause, but it seems better after making this change and developing monorise locally.