### PR TITLE
fix: unique field validation bug fix

### DIFF
--- a/.changeset/rare-hands-search.md
+++ b/.changeset/rare-hands-search.md
@@ -1,0 +1,5 @@
+---
+"@monorise/core": patch
+---
+
+unique field validation bug fix

--- a/packages/core/data/Entity.ts
+++ b/packages/core/data/Entity.ts
@@ -616,8 +616,9 @@ export class EntityRepository extends Repository {
         // check if any of the unique fields has changed
         updatedUniqueFields = uniqueFields.filter(
           (field) =>
+            toUpdate.data[field] !== undefined &&
             (toUpdate.data as Record<string, unknown>)[field] !==
-            (previousEntity.data as Record<string, unknown>)[field],
+              (previousEntity.data as Record<string, unknown>)[field],
         );
 
         previousUniqueFieldValues = updatedUniqueFields.reduce(

--- a/packages/core/data/Entity.ts
+++ b/packages/core/data/Entity.ts
@@ -423,32 +423,21 @@ export class EntityRepository extends Repository {
 
     const uniqueFields = (this.EntityConfig[entityType].uniqueFields ||
       []) as string[];
+    const uniqueFieldValues: Record<string, string> = {};
 
-    const hasUniqueFields = Object.keys(entityPayload).some((field) =>
-      uniqueFields.includes(field),
-    );
+    for (const field of uniqueFields) {
+      if (!(field in entityPayload)) continue;
 
-    let uniqueFieldValues: Record<string, string> = {};
-
-    if (hasUniqueFields) {
-      for (const field of uniqueFields) {
-        if (
-          typeof (entityPayload as Record<string, string>)[field] !== 'string'
-        ) {
-          throw new StandardError(
-            StandardErrorCode.INVALID_UNIQUE_VALUE_TYPE,
-            `Invalid type. ${field} is not a 'string'.`,
-          );
-        }
+      if (
+        typeof (entityPayload as Record<string, string>)[field] !== 'string'
+      ) {
+        throw new StandardError(
+          StandardErrorCode.INVALID_UNIQUE_VALUE_TYPE,
+          `Invalid type. ${field} is not a 'string'.`,
+        );
       }
 
-      uniqueFieldValues = uniqueFields.reduce(
-        (acc, field) => ({
-          ...acc,
-          [field]: (entityPayload as Record<string, unknown>)[field],
-        }),
-        {},
-      );
+      uniqueFieldValues[field] = entityPayload[field];
     }
 
     const TransactItems = this.createEntityTransactItems<T>(entity, {


### PR DESCRIPTION
- unique field type checking should be skipped when the field is not in `entityPayload`
- to reproduce:
  - entity config specify `uniqueFields: ['email', 'phoneNumber']`
  - call `createEntity()` with payload `{ email: 'abc@abc.abc', name: 'test' }`
  - because `email` is unique field, `hasUniqueFields` flag will become `true`, but `entityPayload.phoneNumber` is `undefined`, hence the error `INVALID_UNIQUE_VALUE_TYPE` is thrown