### PR TITLE
Feat/monorepo path support

### DIFF
--- a/.changeset/shaky-parrots-dig.md
+++ b/.changeset/shaky-parrots-dig.md
@@ -1,0 +1,12 @@
+---
+"@monorise/cli": patch
+"@monorise/sst": patch
+---
+
+update:
+
+- sst: support `configRoot`
+- sst: piggyback fix tsconfig.json indefinite loop when build
+- sst: comment out unused send alarm handler
+- cli: support `--config-root`
+- cli: piggyback fix tsconfig.json indefinite loop when build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,4 +74,3 @@ jobs:
         run: |
           npm -w @monorise/sst run sst:install
           npm run build
-          chmod +x packages/cli/dist/cli.js

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "packageManager": "npm@10.9.2",
   "scripts": {
-    "build": "npm run clear-dist && turbo run build -- --force && chmod +x packages/cli/dist/cli.js",
+    "build": "npm run clear-dist && turbo run build && chmod +x packages/cli/dist/cli.js",
     "dev": "npm run clear-dist && turbo run dev",
     "clear-dist": "./scripts/clear.sh",
     "release": "npm run build && npm run changeset -- publish",

--- a/packages/cli/commands/utils/generate.ts
+++ b/packages/cli/commands/utils/generate.ts
@@ -224,9 +224,10 @@ export const appHandler = AppHandler({
   return handleOutputPath;
 }
 
-async function generateFiles(): Promise<string> {
-  const configFilePathTS = path.resolve('./monorise.config.ts');
-  const configFilePathJS = path.resolve('./monorise.config.js');
+async function generateFiles(rootPath?: string): Promise<string> {
+  const baseDir = rootPath ? path.resolve(rootPath) : process.cwd();
+  const configFilePathTS = path.join(baseDir, 'monorise.config.ts');
+  const configFilePathJS = path.join(baseDir, 'monorise.config.js');
 
   let configFilePath: string;
   if (fs.existsSync(configFilePathTS)) {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
     "monorise": "dist/cli.js"
   },
   "scripts": {
-    "build": "tsc -b",
+    "build": "tsc -b && chmod +x dist/cli.js",
     "dev": "tsc -b --watch"
   },
   "keywords": [],

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -110,5 +110,6 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
-  }
+  },
+  "exclude": ["dist/**/*"]
 }

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -110,5 +110,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "exclude": ["./**/__tests__/**/*", "./helpers/test/*"]
+  "exclude": ["dist/**/*", "./**/__tests__/**/*", "./helpers/test/*"]
 }

--- a/packages/sst/components/monorise-core.ts
+++ b/packages/sst/components/monorise-core.ts
@@ -1,12 +1,14 @@
-import { SingleTable } from './single-table';
+import path from 'node:path';
 import { EVENT, SOURCE } from '../constants/event';
 import { QFunction } from './q-function';
+import { SingleTable } from './single-table';
 
 type MonoriseCoreArgs = {
   tableTtl?: string;
   slackWebhook?: string;
   allowHeaders?: string[];
   allowOrigins?: string[];
+  configRoot?: string;
 };
 
 export class MonoriseCore {
@@ -18,11 +20,15 @@ export class MonoriseCore {
 
   constructor(id: string, args?: MonoriseCoreArgs) {
     const runtime: sst.aws.FunctionArgs['runtime'] = 'nodejs22.x';
+    const configRootCommand = args?.configRoot
+      ? `--config-root ${args.configRoot}`
+      : '';
+    const dotMonorisePath = path.join(args?.configRoot ?? '', '.monorise');
 
     new sst.x.DevCommand('Monorise', {
       dev: {
         autostart: true,
-        command: 'npx monorise dev',
+        command: `npx monorise dev ${configRootCommand}`,
       },
     });
 
@@ -45,12 +51,13 @@ export class MonoriseCore {
     this.table = new SingleTable(id, {
       ttl: args?.tableTtl,
       runtime,
+      configRoot: args?.configRoot,
     });
 
     const secretApiKeys = new sst.Secret('API_KEYS', '["secret1", "secret2"]');
 
     this.api.route('ANY /core/{proxy+}', {
-      handler: '.monorise/handle.appHandler',
+      handler: `${dotMonorisePath}/handle.appHandler`,
       link: [this.table.table, this.bus, secretApiKeys],
       environment: {
         API_KEYS: secretApiKeys.value,
@@ -60,36 +67,36 @@ export class MonoriseCore {
     });
 
     this.alarmTopic = new sst.aws.SnsTopic(`${id}-monorise-dlq-alarm-topic`);
-    this.alarmTopic.subscribe('send-cloudwatch-alarm', {
-      name: `${$app.stage}-${id}-monorise-send-cloudwatch-alarm`,
-      handler:
-        'node_modules/monorise/sst/function/send-cloudwatch-alarm.handler',
-      memory: '512 MB',
-      runtime,
-      environment: args?.slackWebhook
-        ? { SLACK_MONITOR_WEBHOOK: args.slackWebhook }
-        : undefined,
-    });
+    // this.alarmTopic.subscribe('send-cloudwatch-alarm', {
+    //   name: `${$app.stage}-${id}-monorise-send-cloudwatch-alarm`,
+    //   handler:
+    //     'node_modules/monorise/sst/function/send-cloudwatch-alarm.handler',
+    //   memory: '512 MB',
+    //   runtime,
+    //   environment: args?.slackWebhook
+    //     ? { SLACK_MONITOR_WEBHOOK: args.slackWebhook }
+    //     : undefined,
+    // });
 
-    this.bus.subscribe(
-      'send-error-message',
-      {
-        name: `${$app.stage}-${id}-monorise-send-error-message`,
-        handler:
-          'node_modules/monorise/sst/function/send-error-message.handler',
-        memory: '512 MB',
-        runtime,
-        environment: args?.slackWebhook
-          ? { SLACK_MONITOR_WEBHOOK: args.slackWebhook }
-          : undefined,
-      },
-      {
-        pattern: {
-          source: [EVENT.GENERAL.ENDPOINT_ERROR.Source],
-          detailType: [EVENT.GENERAL.ENDPOINT_ERROR.DetailType],
-        },
-      },
-    );
+    // this.bus.subscribe(
+    //   'send-error-message',
+    //   {
+    //     name: `${$app.stage}-${id}-monorise-send-error-message`,
+    //     handler:
+    //       'node_modules/monorise/sst/function/send-error-message.handler',
+    //     memory: '512 MB',
+    //     runtime,
+    //     environment: args?.slackWebhook
+    //       ? { SLACK_MONITOR_WEBHOOK: args.slackWebhook }
+    //       : undefined,
+    //   },
+    //   {
+    //     pattern: {
+    //       source: [EVENT.GENERAL.ENDPOINT_ERROR.Source],
+    //       detailType: [EVENT.GENERAL.ENDPOINT_ERROR.DetailType],
+    //     },
+    //   },
+    // );
 
     const environment = {
       CORE_TABLE: this.table.table.name,
@@ -101,7 +108,7 @@ export class MonoriseCore {
      */
     const mutualProcessor = new QFunction('mutual', {
       name: `${$app.stage}-${$app.name}-${id}-mutual-processor`,
-      handler: '.monorise/handle.mutualHandler',
+      handler: `${dotMonorisePath}/handle.mutualHandler`,
       memory: '512 MB',
       timeout: '30 seconds',
       visibilityTimeout: '30 seconds',
@@ -113,7 +120,7 @@ export class MonoriseCore {
 
     const tagProcessor = new QFunction('tag', {
       name: `${$app.stage}-${$app.name}-${id}-tag-processor`,
-      handler: '.monorise/handle.tagHandler',
+      handler: `${dotMonorisePath}/handle.tagHandler`,
       memory: '512 MB',
       timeout: '30 seconds',
       visibilityTimeout: '30 seconds',
@@ -125,7 +132,7 @@ export class MonoriseCore {
 
     const treeProcessor = new QFunction('tree', {
       name: `${$app.stage}-${$app.name}-${id}-tree-processor`,
-      handler: '.monorise/handle.treeHandler',
+      handler: `${dotMonorisePath}/handle.treeHandler`,
       memory: '512 MB',
       timeout: '30 seconds',
       visibilityTimeout: '30 seconds',

--- a/packages/sst/components/single-table.ts
+++ b/packages/sst/components/single-table.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import {
   ENTITY_REPLICATION_INDEX,
   MUTUAL_REPLICATION_INDEX,
@@ -6,6 +7,7 @@ import {
 type SingleTableArgs = {
   ttl?: string;
   runtime?: sst.aws.FunctionArgs['runtime'];
+  configRoot?: string;
 };
 
 export class SingleTable {
@@ -63,7 +65,10 @@ export class SingleTable {
     this.table.subscribe(
       `${id}-core-replicator`,
       {
-        handler: '.monorise/handle.replicationHandler',
+        handler: path.join(
+          args?.configRoot ?? '',
+          '.monorise/handle.replicationHandler',
+        ),
         timeout: '60 seconds',
         memory: '512 MB',
         runtime: args?.runtime,

--- a/packages/sst/tsconfig.json
+++ b/packages/sst/tsconfig.json
@@ -110,5 +110,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "exclude": ["./**/__tests__/**/*", "./helpers/test/*"]
+  "exclude": ["dist/**/*"]
 }


### PR DESCRIPTION
# what
- scenario to allow multiple monorepo to run it's own `monorise` instance, eg
```
root-folder/packages/A-service
root-folder/packages/B-service
```
the existing implementations are assume we only have one monorise in the repo, but what if we wanted to have 2 to split things up

# solution
- make `monorise.config.ts` location to be dynamic

# piggyback
- fix tsconfig indefinite build due to source code were placed at the same level as `dist/` folder, which triggers build source code > dist created > watcher thought dist is some source code changes > rebuild