### PR TITLE
fix: unique field replication

### DIFF
--- a/.changeset/sour-mirrors-care.md
+++ b/.changeset/sour-mirrors-care.md
@@ -1,0 +1,5 @@
+---
+"@monorise/core": patch
+---
+
+bug fix on unique field record will not get update if `updatedAt` attribute is not exists

--- a/packages/core/processors/replication-processor.ts
+++ b/packages/core/processors/replication-processor.ts
@@ -50,7 +50,7 @@ export const handler =
             ExpressionAttributeNames: Record<string, string>;
             ExpressionAttributeValues: Record<string, AttributeValue>;
           } = {
-            FilterExpression: `#${targetUpdatedAt} < :${targetUpdatedAt}`,
+            FilterExpression: `attribute_not_exists(#${targetUpdatedAt}) OR #${targetUpdatedAt} < :${targetUpdatedAt}`,
             ExpressionAttributeNames: {
               [`#${targetRPK}`]: targetRPK,
               [`#${targetUpdatedAt}`]: targetUpdatedAt,
@@ -68,12 +68,14 @@ export const handler =
             ExpressionAttributeValues: Record<string, AttributeValue>;
           } = {
             UpdateExpression: `SET #${targetUpdatedAt} = :${targetUpdatedAt}, #${targetData} = :${targetData}`,
-            ConditionExpression: `#${targetUpdatedAt} < :${targetUpdatedAt}`,
+            ConditionExpression: `#PK <> :PK AND (attribute_not_exists(#${targetUpdatedAt}) OR #${targetUpdatedAt} < :${targetUpdatedAt})`,
             ExpressionAttributeNames: {
+              '#PK': 'PK',
               [`#${targetData}`]: targetData,
               [`#${targetUpdatedAt}`]: targetUpdatedAt,
             },
             ExpressionAttributeValues: {
+              ':PK': modifiedItem.PK,
               [`:${targetData}`]: modifiedItem.data,
               [`:${targetUpdatedAt}`]: modifiedItem.updatedAt,
             },


### PR DESCRIPTION
- potential bug: if a unique field record (eg: `UNQUE#email#xxx`) is inserted without `updatedAt` attribute, replication processor will not recognize it in subsequent entity updates
- to reproduce:
  - find a unique field record `UNQUE#email#xxx` in dynamodb
  - remove the `updatedAt` attribute
  - perform update on its corresponding `#METADATA#` entity
  - the unique field record will not get update with latest data, because the `ConditionExpression: #${targetUpdatedAt} < :${targetUpdatedAt}` is always false when `updatedAt` attribute is not exists