### PR TITLE
Jy/fix/monorise config relative config root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4875,10 +4875,6 @@
         "obliterator": "^1.6.1"
       }
     },
-    "node_modules/monorise": {
-      "resolved": "packages/monorise",
-      "link": true
-    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -6945,7 +6941,7 @@
     },
     "packages/cli": {
       "name": "@monorise/cli",
-      "version": "1.0.0-dev.0",
+      "version": "1.0.0-dev.1",
       "license": "ISC",
       "dependencies": {
         "chokidar": "^4.0.3",
@@ -6990,11 +6986,12 @@
     },
     "packages/monorise": {
       "version": "0.0.0",
+      "extraneous": true,
       "license": "ISC"
     },
     "packages/react": {
       "name": "@monorise/react",
-      "version": "1.0.0-dev.0",
+      "version": "1.0.0-dev.1",
       "license": "ISC",
       "dependencies": {
         "@tabler/icons-react": "^3.30.0",
@@ -7033,7 +7030,7 @@
     },
     "packages/sst": {
       "name": "@monorise/sst",
-      "version": "1.0.0-dev.1",
+      "version": "1.0.0-dev.2",
       "license": "ISC",
       "devDependencies": {
         "@types/aws-lambda": "8.10.149"

--- a/packages/cli/cli.ts
+++ b/packages/cli/cli.ts
@@ -447,7 +447,7 @@ async function main() {
       await runInitCommand(rootPath);
     } else {
       console.error(
-        'Unknown command. Usage: monorise [dev|build|init] [--root <path>]',
+        'Unknown command. Usage: monorise [dev|build|init] [--config-root <path>]',
       );
       process.exit(1);
     }

--- a/packages/cli/cli.ts
+++ b/packages/cli/cli.ts
@@ -259,7 +259,7 @@ async function generateFiles(rootPath?: string): Promise<string> {
   const monoriseConfigModule = await import(configFilePath);
   const monoriseConfig = monoriseConfigModule.default;
 
-  const configDir = path.resolve(monoriseConfig.configDir);
+  const configDir = path.resolve(projectRoot, monoriseConfig.configDir);
   const monoriseOutputDir = path.join(projectRoot, '.monorise');
 
   fs.mkdirSync(monoriseOutputDir, { recursive: true });


### PR DESCRIPTION
# what
- monorise.config.ts read path inconsistency, causing `dev` and `build` command not working expected
- piggyback: help manual update to --config-root