### PR TITLE
fix: tag processor race condition

### DIFF
--- a/.changeset/clever-boats-pick.md
+++ b/.changeset/clever-boats-pick.md
@@ -1,0 +1,5 @@
+---
+"@monorise/core": patch
+---
+
+fix tag processor race condition

--- a/packages/core/processors/tag-processor.ts
+++ b/packages/core/processors/tag-processor.ts
@@ -82,6 +82,7 @@ async function batchUpdateTags({
     ],
     [] as Promise<any>[],
   );
+  await Promise.all(removePromises);
 
   const addPromises = tagsToAdd.reduce(
     (acc, tag) => [
@@ -95,8 +96,7 @@ async function batchUpdateTags({
     ],
     [] as Promise<any>[],
   );
-
-  await Promise.all([...removePromises, ...addPromises]);
+  await Promise.all(addPromises);
 }
 
 export const handler =


### PR DESCRIPTION
- fix race condition occurred in tag processor when updating tag data

scenario:
- term definition
  - `tag-record`: `{ PK: 'TAG#...#{tag.group}', SK: '{tag.sortValue}#...' }`
  - `reversed-key-record`: `{ PK: 'entity#entity-id', SK: 'TAG#...#{tag.group}' }`
- whenever we insert a `tag-record`, we will also insert a `reversed-key-record` which will be used in [getExistingTags()](https://github.com/monorist/monorise/blob/ea5dcc602ef74f9094555ea814ac9057865c4951/packages/core/data/Tag.ts#L128)
- when the tag value gets updated, we will delete the old `tag-record` & `reversed-key-record` and insert a new pair of `tag-record` & `reversed-key-record`
- this works fine if the new `tag.group` value is different from the old one
- but if the `tag.group` value remain the same and only `tag.sortValue` changed, the old and new `reversed-key-record` will have same pair of `PK` & `SK`
- and we are deleting & re-creating `reversed-key-record` with same pair of `PK` & `SK` at the same time in `Promise.all()`, hence race condition happened