### PR TITLE
fix: unique field missing updatedAt timestamp

### DIFF
--- a/.changeset/big-clowns-yell.md
+++ b/.changeset/big-clowns-yell.md
@@ -1,0 +1,5 @@
+---
+"@monorise/core": patch
+---
+
+fix unique field missing updatedAt timestamp

--- a/packages/core/data/Entity.ts
+++ b/packages/core/data/Entity.ts
@@ -395,6 +395,8 @@ export class EntityRepository extends Repository {
             SK: { S: entity.entityType as unknown as string },
             R1PK: entity.keys().PK,
             R1SK: entity.keys().SK,
+            createdAt: { S: entity.createdAt || new Date().toISOString() },
+            updatedAt: { S: entity.updatedAt || new Date().toISOString() },
           },
         },
       });
@@ -551,6 +553,13 @@ export class EntityRepository extends Repository {
               SK: { S: entity.entityType as unknown as string },
               R1PK: entity.keys().PK,
               R1SK: entity.keys().SK,
+              createdAt: {
+                S:
+                  previousEntity.createdAt ||
+                  entity.createdAt ||
+                  new Date().toISOString(),
+              },
+              updatedAt: { S: entity.updatedAt || new Date().toISOString() },
             },
           },
         },


### PR DESCRIPTION
- another approach to fix issue mentioned in #140 
- also I have noticed the `updatedAt` attribute will be removed from the `UNIQUE#...` record when there is a change in unique field values