### PR TITLE
Fix combined package DTS rewriting and CLI monorepo detection

### DIFF
--- a/.changeset/fix-combined-package-dts-and-cli.md
+++ b/.changeset/fix-combined-package-dts-and-cli.md
@@ -1,0 +1,9 @@
+---
+"@monorise/cli": patch
+"monorise": patch
+---
+
+Fix combined package DTS rewriting and CLI monorepo detection
+
+- build.js: Fix regex that missed rewriting some `@monorise/*` imports in `.d.ts` files (global regex `lastIndex` bug + missing double-quote patterns)
+- cli: Add `detectCombinedPackage()` that walks up directory tree for monorepo hoisting support, and generate correct module augmentation based on detection

--- a/packages/cli/cli.ts
+++ b/packages/cli/cli.ts
@@ -5,24 +5,7 @@ import 'tsconfig-paths/register.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import chokidar from 'chokidar';
-
-/**
- * Detects whether the combined 'monorise' package is installed by walking up
- * the directory tree. This handles monorepo setups where dependencies are
- * hoisted to the root node_modules.
- */
-function detectCombinedPackage(startDir: string): boolean {
-  let dir = startDir;
-  while (true) {
-    if (fs.existsSync(path.join(dir, 'node_modules', 'monorise'))) {
-      return true;
-    }
-    const parent = path.dirname(dir);
-    if (parent === dir) break; // reached filesystem root
-    dir = parent;
-  }
-  return false;
-}
+import { detectCombinedPackage } from './commands/utils/detect-package';
 
 function kebabToCamel(str: string): string {
   return str.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());

--- a/packages/cli/cli.ts
+++ b/packages/cli/cli.ts
@@ -6,6 +6,24 @@ import fs from 'node:fs';
 import path from 'node:path';
 import chokidar from 'chokidar';
 
+/**
+ * Detects whether the combined 'monorise' package is installed by walking up
+ * the directory tree. This handles monorepo setups where dependencies are
+ * hoisted to the root node_modules.
+ */
+function detectCombinedPackage(startDir: string): boolean {
+  let dir = startDir;
+  while (true) {
+    if (fs.existsSync(path.join(dir, 'node_modules', 'monorise'))) {
+      return true;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break; // reached filesystem root
+    dir = parent;
+  }
+  return false;
+}
+
 function kebabToCamel(str: string): string {
   return str.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
 }
@@ -93,8 +111,26 @@ export enum Entity {}
   }
 
   // Detect whether the consumer uses the combined 'monorise' package or scoped '@monorise/*' packages
-  const usesCombinedPackage = fs.existsSync(path.join(projectRoot, 'node_modules', 'monorise'));
-  const baseModuleName = usesCombinedPackage ? 'monorise/base' : '@monorise/base';
+  const usesCombinedPackage = detectCombinedPackage(projectRoot);
+
+  // Build module augmentation block
+  const augmentationBlock = (moduleName: string) => `
+declare module '${moduleName}' {
+  export enum Entity {
+    ${enumEntries.join(',\n    ')}
+  }
+
+  ${typeEntries.join('\n  ')}
+
+  export interface EntitySchemaMap {
+    ${schemaMapEntries.join('\n    ')}
+  }
+}`;
+
+  // Augment the correct module based on which package is installed
+  const moduleAugmentations = usesCombinedPackage
+    ? augmentationBlock('monorise/base')
+    : augmentationBlock('@monorise/base');
 
   const configOutputContent = `
 import type { z } from 'zod';
@@ -139,18 +175,7 @@ const config = {
 };
 
 export default config;
-
-declare module '${baseModuleName}' {
-  export enum Entity {
-    ${enumEntries.join(',\n    ')}
-  }
-
-  ${typeEntries.join('\n  ')}
-
-  export interface EntitySchemaMap {
-    ${schemaMapEntries.join('\n    ')}
-  }
-}
+${moduleAugmentations}
 `;
 
   fs.writeFileSync(configOutputPath, configOutputContent);
@@ -227,7 +252,7 @@ async function generateHandleFile(
   // If customRoutesPath is not provided, routesImportLine remains empty and appHandlerPayload remains `{}`
 
   // Detect whether the consumer uses the combined 'monorise' package or scoped '@monorise/*' packages
-  const usesCombinedPackage = fs.existsSync(path.join(projectRoot, 'node_modules', 'monorise'));
+  const usesCombinedPackage = detectCombinedPackage(projectRoot);
   const coreImportPath = usesCombinedPackage ? 'monorise/core' : '@monorise/core';
 
   const combinedContent = `

--- a/packages/cli/commands/utils/detect-package.ts
+++ b/packages/cli/commands/utils/detect-package.ts
@@ -1,0 +1,20 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Detects whether the combined 'monorise' package is installed by walking up
+ * the directory tree. This handles monorepo setups where dependencies are
+ * hoisted to the root node_modules.
+ */
+export function detectCombinedPackage(startDir: string): boolean {
+  let dir = startDir;
+  while (true) {
+    if (fs.existsSync(path.join(dir, 'node_modules', 'monorise'))) {
+      return true;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break; // reached filesystem root
+    dir = parent;
+  }
+  return false;
+}

--- a/packages/cli/commands/utils/generate.ts
+++ b/packages/cli/commands/utils/generate.ts
@@ -1,23 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
-
-/**
- * Detects whether the combined 'monorise' package is installed by walking up
- * the directory tree. This handles monorepo setups where dependencies are
- * hoisted to the root node_modules.
- */
-function detectCombinedPackage(startDir: string): boolean {
-  let dir = startDir;
-  while (true) {
-    if (fs.existsSync(path.join(dir, 'node_modules', 'monorise'))) {
-      return true;
-    }
-    const parent = path.dirname(dir);
-    if (parent === dir) break; // reached filesystem root
-    dir = parent;
-  }
-  return false;
-}
+import { detectCombinedPackage } from './detect-package';
 
 function kebabToCamel(str: string): string {
   return str.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());

--- a/packages/cli/commands/utils/generate.ts
+++ b/packages/cli/commands/utils/generate.ts
@@ -1,6 +1,24 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+/**
+ * Detects whether the combined 'monorise' package is installed by walking up
+ * the directory tree. This handles monorepo setups where dependencies are
+ * hoisted to the root node_modules.
+ */
+function detectCombinedPackage(startDir: string): boolean {
+  let dir = startDir;
+  while (true) {
+    if (fs.existsSync(path.join(dir, 'node_modules', 'monorise'))) {
+      return true;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break; // reached filesystem root
+    dir = parent;
+  }
+  return false;
+}
+
 function kebabToCamel(str: string): string {
   return str.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
 }
@@ -214,8 +232,11 @@ async function generateHandleFile(
   );
   relativePathToRoutes = relativePathToRoutes.replace(/\.(ts|js|mjs|cjs)$/, '');
 
+  const usesCombinedPackage = detectCombinedPackage(projectRoot);
+  const coreImportPath = usesCombinedPackage ? 'monorise/core' : '@monorise/core';
+
   const combinedContent = `
-import { AppHandler, CoreFactory } from '@monorise/core';
+import { AppHandler, CoreFactory } from '${coreImportPath}';
 import config from './config';
 import routes from '${relativePathToRoutes}';
 

--- a/packages/monorise/build.js
+++ b/packages/monorise/build.js
@@ -49,7 +49,7 @@ function rewriteImports(dir, currentPkg) {
       rewriteImports(fullPath, currentPkg);
     } else if (entry.name.endsWith('.d.ts')) {
       let content = fs.readFileSync(fullPath, 'utf-8');
-      let changed = false;
+      const original = content;
       for (const [pkg, folder] of Object.entries(packageMap)) {
         if (folder === currentPkg) continue;
         const relativePath = path.relative(
@@ -59,21 +59,19 @@ function rewriteImports(dir, currentPkg) {
         const relativeImport = relativePath.startsWith('.')
           ? relativePath
           : `./${relativePath}`;
-        const fromRegex = new RegExp(`'${pkg.replace('/', '\\/')}'`, 'g');
-        const importRegex = new RegExp(
-          `import\\("${pkg.replace('/', '\\/')}"\\)`,
-          'g',
+        const escapedPkg = pkg.replace('/', '\\/');
+        // Match both single and double quoted from/import patterns
+        // e.g. from '@monorise/base', from "@monorise/base", import("@monorise/base")
+        content = content.replace(
+          new RegExp(`'${escapedPkg}'`, 'g'),
+          `'${relativeImport}'`,
         );
-        if (fromRegex.test(content) || importRegex.test(content)) {
-          content = content.replace(fromRegex, `'${relativeImport}'`);
-          content = content.replace(
-            importRegex,
-            `import("${relativeImport}")`,
-          );
-          changed = true;
-        }
+        content = content.replace(
+          new RegExp(`"${escapedPkg}"`, 'g'),
+          `"${relativeImport}"`,
+        );
       }
-      if (changed) {
+      if (content !== original) {
         fs.writeFileSync(fullPath, content);
       }
     }

--- a/www/package.json
+++ b/www/package.json
@@ -11,5 +11,5 @@
     "vitepress": "^1.6.3",
     "vue": "^3.5.13"
   },
-  "version": null
+  "version": "0.0.0"
 }


### PR DESCRIPTION
## Fixes two bugs affecting users of the combined monorise package in monorepo setups.

### Bug 1: DTS import rewriting misses @monorise/* references (build.js)

  The regex in build.js failed to rewrite all @monorise/* imports to relative paths in.d.ts files due to:
  1. .test() advancing global regex lastIndex before .replace(), skipping the first match
  2. Only matching single-quoted patterns — missing import("@monorise/base") (double
  quotes)

  Fix: Direct .replace() calls for both quote styles, simple string comparison for change
  detection.

### Bug 2: CLI fails to detect combined package in monorepos (cli.ts)

  The CLI checked projectRoot/node_modules/monorise to detect the combined package, but in workspaces dependencies are hoisted to root node_modules/. This caused wrong import paths in handle.ts and TS2664 errors from invalid module augmentation blocks.

  Fix: Added detectCombinedPackage() that walks up the directory tree (mirroring Node.js resolution). The CLI now generates only the relevant module augmentation based on detection — monorise/base for combined, @monorise/base for scoped.
  
  
<img width="558" height="58" alt="image" src="https://github.com/user-attachments/assets/e880ee5d-d90c-49cc-8c8d-ac3191ca497d" />
