### PR TITLE
Add adjustEntity for atomic numeric updates

### DIFF
--- a/.changeset/add-adjust-entity.md
+++ b/.changeset/add-adjust-entity.md
@@ -1,0 +1,8 @@
+---
+"@monorise/base": minor
+"@monorise/core": minor
+"@monorise/react": minor
+"monorise": minor
+---
+
+Add adjustEntity for atomic numeric updates on entity fields. Uses DynamoDB's native arithmetic expressions (SET field = field + delta) for race-condition-free concurrent writes. Useful for counters, accumulators, and real-time metrics.

--- a/packages/base/index.ts
+++ b/packages/base/index.ts
@@ -4,6 +4,7 @@ import {
   Entity,
   EntitySchemaMap,
   MonoriseEntityConfig,
+  NumericFields,
 } from './types/monorise.type';
 
 import { createEntityConfig } from './utils';
@@ -14,5 +15,6 @@ export {
   DraftEntity,
   CreatedEntity,
   MonoriseEntityConfig,
+  NumericFields,
   createEntityConfig,
 };

--- a/packages/base/types/monorise.type.ts
+++ b/packages/base/types/monorise.type.ts
@@ -241,16 +241,31 @@ export interface MonoriseEntityConfig<
    * ```ts
    * {
    *   adjustmentConstraints: {
-   *     balance: { min: 0 },           // balance cannot go below 0
-   *     credits: { min: 0, max: 10000 }, // credits must stay between 0 and 10000
+   *     // Static: same for all entities of this type
+   *     balance: { min: 0 },
+   *     credits: { min: 0, max: 10000 },
+   *
+   *     // Dynamic: reads constraint value from entity's own data
+   *     balance: { minField: 'minBalance' },
+   *     credits: { min: 0, maxField: 'creditLimit' },
    *   }
    * }
    * ```
    */
   adjustmentConstraints?: {
     [fieldName: string]: {
+      /** Static minimum value */
       min?: number;
+      /** Static maximum value */
       max?: number;
+      /** Field name on the entity whose value is used as the minimum (must be a numeric field) */
+      minField?: keyof {
+        [K in keyof B as B[K] extends z.ZodNumber | z.ZodOptional<z.ZodNumber> ? K : never]: K;
+      };
+      /** Field name on the entity whose value is used as the maximum (must be a numeric field) */
+      maxField?: keyof {
+        [K in keyof B as B[K] extends z.ZodNumber | z.ZodOptional<z.ZodNumber> ? K : never]: K;
+      };
     };
   };
 }

--- a/packages/base/types/monorise.type.ts
+++ b/packages/base/types/monorise.type.ts
@@ -231,4 +231,26 @@ export interface MonoriseEntityConfig<
       sortValue?: string;
     }[];
   }[];
+
+  /**
+   * @description (Optional) Constraints for `adjustEntity` operations.
+   * When adjusting numeric fields, these constraints are enforced at the database level.
+   * If an adjustment would violate a constraint, the operation is rejected.
+   *
+   * @example
+   * ```ts
+   * {
+   *   adjustmentConstraints: {
+   *     balance: { min: 0 },           // balance cannot go below 0
+   *     credits: { min: 0, max: 10000 }, // credits must stay between 0 and 10000
+   *   }
+   * }
+   * ```
+   */
+  adjustmentConstraints?: {
+    [fieldName: string]: {
+      min?: number;
+      max?: number;
+    };
+  };
 }

--- a/packages/base/types/monorise.type.ts
+++ b/packages/base/types/monorise.type.ts
@@ -9,6 +9,10 @@ export interface EntitySchemaMap {
 export type DraftEntity<T extends Entity = Entity> =
   T extends keyof EntitySchemaMap ? EntitySchemaMap[T] : never;
 
+export type NumericFields<T> = {
+  [K in keyof T as T[K] extends number ? K : never]?: number;
+};
+
 export type CreatedEntity<T extends Entity = Entity> = {
   entityId: string;
   entityType: string;

--- a/packages/core/controllers/entity/adjust-entity.controller.ts
+++ b/packages/core/controllers/entity/adjust-entity.controller.ts
@@ -37,13 +37,22 @@ export class AdjustEntityController {
 
       c.status(httpStatus.OK);
       return c.json(entity.toJSON());
-    } catch (err) {
+    } catch (err: any) {
       if (
         err instanceof StandardError &&
         err.code === StandardErrorCode.ENTITY_IS_UNDEFINED
       ) {
         c.status(httpStatus.NOT_FOUND);
         return c.json({ ...err.toJSON() });
+      }
+
+      // DynamoDB ConditionalCheckFailedException — constraint violated
+      if (err?.name === 'ConditionalCheckFailedException' || err?.__type?.includes('ConditionalCheckFailed')) {
+        c.status(httpStatus.CONFLICT);
+        return c.json({
+          code: 'ADJUSTMENT_CONSTRAINT_VIOLATED',
+          message: 'Adjustment would violate entity constraints',
+        });
       }
 
       console.log('====ADJUST_ENTITY_CONTROLLER_ERROR', err);

--- a/packages/core/controllers/entity/adjust-entity.controller.ts
+++ b/packages/core/controllers/entity/adjust-entity.controller.ts
@@ -1,0 +1,53 @@
+import type { Entity } from '@monorise/base';
+import { createMiddleware } from 'hono/factory';
+import httpStatus from 'http-status';
+import { StandardError, StandardErrorCode } from '../../errors/standard-error';
+import type { EntityService } from '../../services/entity.service';
+
+export class AdjustEntityController {
+  constructor(private entityService: EntityService) {}
+
+  controller = createMiddleware(async (c) => {
+    const accountId = c.req.header('account-id') || '';
+    const { entityType, entityId } = c.req.param() as {
+      entityType: Entity;
+      entityId: string;
+    };
+
+    const body = await c.req.json();
+
+    // Validate all values are numbers
+    for (const [key, value] of Object.entries(body)) {
+      if (typeof value !== 'number') {
+        c.status(httpStatus.BAD_REQUEST);
+        return c.json({
+          code: 'API_VALIDATION_ERROR',
+          message: `Field "${key}" must be a number, got ${typeof value}`,
+        });
+      }
+    }
+
+    try {
+      const entity = await this.entityService.adjustEntity({
+        entityType,
+        entityId,
+        adjustments: body,
+        accountId,
+      });
+
+      c.status(httpStatus.OK);
+      return c.json(entity.toJSON());
+    } catch (err) {
+      if (
+        err instanceof StandardError &&
+        err.code === StandardErrorCode.ENTITY_IS_UNDEFINED
+      ) {
+        c.status(httpStatus.NOT_FOUND);
+        return c.json({ ...err.toJSON() });
+      }
+
+      console.log('====ADJUST_ENTITY_CONTROLLER_ERROR', err);
+      throw err;
+    }
+  });
+}

--- a/packages/core/controllers/entity/create-entity.controller.ts
+++ b/packages/core/controllers/entity/create-entity.controller.ts
@@ -20,6 +20,7 @@ export class CreateEntityController {
       const entity = await this.entityService.createEntity({
         entityType,
         entityPayload: body,
+        entityId: body.entityId,
         accountId,
         options: {
           createAndUpdateDatetime: body.createdAt,

--- a/packages/core/controllers/setupRoutes.ts
+++ b/packages/core/controllers/setupRoutes.ts
@@ -45,6 +45,10 @@ export const setupCommonRoutes = (container: DependencyContainer): Hono => {
     '/entity/:entityType/unique/:uniqueField/:uniqueFieldValue',
     container.getEntityByUniqueFieldController.controller,
   );
+  app.post(
+    '/entity/:entityType/:entityId/adjust',
+    container.adjustEntityController.controller,
+  );
   app.get(
     '/entity/:entityType/:entityId',
     container.getEntityController.controller,
@@ -60,10 +64,6 @@ export const setupCommonRoutes = (container: DependencyContainer): Hono => {
   app.delete(
     '/entity/:entityType/:entityId',
     container.deleteEntityController.controller,
-  );
-  app.post(
-    '/entity/:entityType/:entityId/adjust',
-    container.adjustEntityController.controller,
   );
 
   /*

--- a/packages/core/controllers/setupRoutes.ts
+++ b/packages/core/controllers/setupRoutes.ts
@@ -61,6 +61,10 @@ export const setupCommonRoutes = (container: DependencyContainer): Hono => {
     '/entity/:entityType/:entityId',
     container.deleteEntityController.controller,
   );
+  app.post(
+    '/entity/:entityType/:entityId/adjust',
+    container.adjustEntityController.controller,
+  );
 
   /*
    * Tag endpoint

--- a/packages/core/data/Entity.ts
+++ b/packages/core/data/Entity.ts
@@ -707,6 +707,31 @@ export class EntityRepository extends Repository {
     }
   }
 
+  async adjustEntity<T extends EntityType>(
+    entityType: T,
+    entityId: string,
+    adjustments: Record<string, number>,
+  ): Promise<Entity<T>> {
+    const entity = new Entity(entityType, entityId);
+    const { UpdateExpression, ExpressionAttributeNames, ExpressionAttributeValues } =
+      this.toAdjustUpdate(adjustments);
+
+    const updatedAtExpression = ', #updatedAt = :updatedAt';
+    ExpressionAttributeNames['#updatedAt'] = 'updatedAt';
+    ExpressionAttributeValues[':updatedAt'] = { S: new Date().toISOString() };
+
+    const resp = await this.dynamodbClient.updateItem({
+      TableName: this.TABLE_NAME,
+      Key: entity.keys(),
+      UpdateExpression: UpdateExpression + updatedAtExpression,
+      ExpressionAttributeNames,
+      ExpressionAttributeValues,
+      ReturnValues: 'ALL_NEW',
+    });
+
+    return Entity.fromItem<T>(resp.Attributes);
+  }
+
   async deleteEntity<T extends EntityType>(
     entityType: T,
     entityId: string,

--- a/packages/core/data/Entity.ts
+++ b/packages/core/data/Entity.ts
@@ -711,7 +711,7 @@ export class EntityRepository extends Repository {
     entityType: T,
     entityId: string,
     adjustments: Record<string, number>,
-    constraints?: { [field: string]: { min?: number; max?: number; minField?: string; maxField?: string } },
+    constraints?: { [field: string]: { min?: number; max?: number } },
   ): Promise<Entity<T>> {
     const entity = new Entity(entityType, entityId);
     const { UpdateExpression, ConditionExpression, ExpressionAttributeNames, ExpressionAttributeValues } =

--- a/packages/core/data/Entity.ts
+++ b/packages/core/data/Entity.ts
@@ -711,7 +711,7 @@ export class EntityRepository extends Repository {
     entityType: T,
     entityId: string,
     adjustments: Record<string, number>,
-    constraints?: { [field: string]: { min?: number; max?: number } },
+    constraints?: { [field: string]: { min?: number; max?: number; minField?: string; maxField?: string } },
   ): Promise<Entity<T>> {
     const entity = new Entity(entityType, entityId);
     const { UpdateExpression, ConditionExpression, ExpressionAttributeNames, ExpressionAttributeValues } =

--- a/packages/core/data/Entity.ts
+++ b/packages/core/data/Entity.ts
@@ -711,10 +711,11 @@ export class EntityRepository extends Repository {
     entityType: T,
     entityId: string,
     adjustments: Record<string, number>,
+    constraints?: { [field: string]: { min?: number; max?: number } },
   ): Promise<Entity<T>> {
     const entity = new Entity(entityType, entityId);
-    const { UpdateExpression, ExpressionAttributeNames, ExpressionAttributeValues } =
-      this.toAdjustUpdate(adjustments);
+    const { UpdateExpression, ConditionExpression, ExpressionAttributeNames, ExpressionAttributeValues } =
+      this.toAdjustUpdate(adjustments, constraints);
 
     const updatedAtExpression = ', #updatedAt = :updatedAt';
     ExpressionAttributeNames['#updatedAt'] = 'updatedAt';
@@ -724,6 +725,7 @@ export class EntityRepository extends Repository {
       TableName: this.TABLE_NAME,
       Key: entity.keys(),
       UpdateExpression: UpdateExpression + updatedAtExpression,
+      ...(ConditionExpression && { ConditionExpression }),
       ExpressionAttributeNames,
       ExpressionAttributeValues,
       ReturnValues: 'ALL_NEW',

--- a/packages/core/data/__tests__/AdjustEntity.test.ts
+++ b/packages/core/data/__tests__/AdjustEntity.test.ts
@@ -1,0 +1,285 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Entity as EntityType } from '../../../base';
+import {
+  MockEntityType,
+  createDynamoDbClient,
+  createMockEntityConfig,
+  createTestTable,
+  deleteTestTable,
+  getTableName,
+} from '../../helpers/test/test-utils';
+import { type Entity, EntityRepository } from '../Entity';
+
+const TABLE_NAME = getTableName();
+const dynamodbClient = createDynamoDbClient();
+const mockEntityConfig = createMockEntityConfig();
+
+const entityRepository = new EntityRepository(
+  mockEntityConfig,
+  TABLE_NAME,
+  dynamodbClient,
+  [],
+);
+
+describe('EntityRepository — adjustEntity', () => {
+  let wallet: Entity<EntityType>;
+
+  beforeAll(async () => {
+    await createTestTable(TABLE_NAME, dynamodbClient);
+    wallet = await entityRepository.createEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      { balance: 100, credits: 50 },
+    );
+  }, 60000);
+
+  afterAll(async () => {
+    await deleteTestTable(TABLE_NAME, dynamodbClient);
+  }, 60000);
+
+  it('should increment a field', async () => {
+    const result = await entityRepository.adjustEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+      { balance: 50 },
+    );
+    expect(result.data.balance).toBe(150);
+    const fetched = await entityRepository.getEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+    );
+    expect(fetched.data.balance).toBe(150);
+    wallet = result;
+  });
+
+  it('should decrement a field', async () => {
+    const result = await entityRepository.adjustEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+      { balance: -30 },
+    );
+    expect(result.data.balance).toBe(120);
+    const fetched = await entityRepository.getEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+    );
+    expect(fetched.data.balance).toBe(120);
+    wallet = result;
+  });
+
+  it('should adjust multiple fields in one call', async () => {
+    const result = await entityRepository.adjustEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+      { balance: 10, credits: 5 },
+    );
+    expect(result.data.balance).toBe(130);
+    expect(result.data.credits).toBe(55);
+    const fetched = await entityRepository.getEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+    );
+    expect(fetched.data.balance).toBe(130);
+    expect(fetched.data.credits).toBe(55);
+    wallet = result;
+  });
+
+  it('should initialize a non-existent field to 0 before applying delta', async () => {
+    const result = await entityRepository.adjustEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+      { score: 10 },
+    );
+    expect(result.data.score).toBe(10);
+    const fetched = await entityRepository.getEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+    );
+    expect(fetched.data.score).toBe(10);
+    wallet = result;
+  });
+
+  it('should bump updatedAt after adjustment', async () => {
+    const beforeUpdatedAt = wallet.updatedAt ?? '';
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const result = await entityRepository.adjustEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+      { balance: 1 },
+    );
+    expect(result.updatedAt).toBeDefined();
+    expect((result.updatedAt ?? '') > beforeUpdatedAt).toBe(true);
+    const fetched = await entityRepository.getEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+    );
+    expect(fetched.updatedAt).toBe(result.updatedAt);
+    wallet = result;
+  });
+
+  it('should not lose data under concurrent adjustments', async () => {
+    const balanceBefore = wallet.data.balance as number;
+    await Promise.all(
+      Array.from({ length: 5 }, () =>
+        entityRepository.adjustEntity(
+          MockEntityType.WALLET as unknown as EntityType,
+          wallet.entityId as string,
+          { balance: 1 },
+        ),
+      ),
+    );
+    const fetched = await entityRepository.getEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+    );
+    expect(fetched.data.balance).toBe(balanceBefore + 5);
+    wallet = fetched;
+  });
+
+  it('should not allow balance to drop below 0 under concurrent decrements', async () => {
+    // Set balance to exactly 3 so only 3 of 5 concurrent decrements can succeed
+    const resetResult = await entityRepository.adjustEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+      { balance: 3 - (wallet.data.balance as number) },
+    );
+    wallet = resetResult;
+
+    const results = await Promise.allSettled(
+      Array.from({ length: 5 }, () =>
+        entityRepository.adjustEntity(
+          MockEntityType.WALLET as unknown as EntityType,
+          wallet.entityId as string,
+          { balance: -1 },
+          { balance: { min: 0 } },
+        ),
+      ),
+    );
+
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    const rejected = results.filter((r) => r.status === 'rejected');
+
+    expect(fulfilled).toHaveLength(3);
+    expect(rejected).toHaveLength(2);
+    expect(
+      rejected.every(
+        (r) =>
+          (r as PromiseRejectedResult).reason?.name ===
+          'ConditionalCheckFailedException',
+      ),
+    ).toBe(true);
+
+    const fetched = await entityRepository.getEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+    );
+    expect(fetched.data.balance).toBe(0);
+    // Restore balance for subsequent tests
+    wallet = await entityRepository.adjustEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      fetched.entityId as string,
+      { balance: 100 },
+    );
+  });
+
+  it('should succeed when decrement stays above static min', async () => {
+    // balance is currently 100; decrementing by 30 stays above min: 0
+    const result = await entityRepository.adjustEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+      { balance: -30 },
+      { balance: { min: 0 } },
+    );
+    expect(result.data.balance).toBe((wallet.data.balance as number) - 30);
+    const fetched = await entityRepository.getEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+    );
+    expect(fetched.data.balance).toBe(result.data.balance);
+    wallet = result;
+  });
+
+  it('should throw when decrement violates static min', async () => {
+    // decrement by 200 would push below min: 0
+    await expect(
+      entityRepository.adjustEntity(
+        MockEntityType.WALLET as unknown as EntityType,
+        wallet.entityId as string,
+        { balance: -200 },
+        { balance: { min: 0 } },
+      ),
+    ).rejects.toMatchObject({ name: 'ConditionalCheckFailedException' });
+    const fetched = await entityRepository.getEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+    );
+    expect(fetched.data.balance).toBe(wallet.data.balance);
+  });
+
+  it('should succeed when increment stays below static max', async () => {
+    // credits: 55; incrementing by 40 stays below max: 100
+    const result = await entityRepository.adjustEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+      { credits: 40 },
+      { credits: { max: 100 } },
+    );
+    expect(result.data.credits).toBe(95);
+    const fetched = await entityRepository.getEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+    );
+    expect(fetched.data.credits).toBe(95);
+    wallet = result;
+  });
+
+  it('should throw when increment violates static max', async () => {
+    // credits: 95; incrementing by 10 would exceed max: 100
+    await expect(
+      entityRepository.adjustEntity(
+        MockEntityType.WALLET as unknown as EntityType,
+        wallet.entityId as string,
+        { credits: 10 },
+        { credits: { max: 100 } },
+      ),
+    ).rejects.toMatchObject({ name: 'ConditionalCheckFailedException' });
+    const fetched = await entityRepository.getEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+    );
+    expect(fetched.data.credits).toBe(wallet.data.credits);
+  });
+
+  it('should not enforce min constraint when incrementing', async () => {
+    // min constraint should be ignored for positive delta
+    const result = await entityRepository.adjustEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+      { balance: 5 },
+      { balance: { min: 0 } },
+    );
+    expect(result.data.balance).toBe((wallet.data.balance as number) + 5);
+    const fetched = await entityRepository.getEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+    );
+    expect(fetched.data.balance).toBe(result.data.balance);
+    wallet = result;
+  });
+
+  it('should not enforce max constraint when decrementing', async () => {
+    // max constraint should be ignored for negative delta
+    const result = await entityRepository.adjustEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+      { credits: -10 },
+      { credits: { max: 100 } },
+    );
+    expect(result.data.credits).toBe(85);
+    const fetched = await entityRepository.getEntity(
+      MockEntityType.WALLET as unknown as EntityType,
+      wallet.entityId as string,
+    );
+    expect(fetched.data.credits).toBe(85);
+    wallet = result;
+  });
+});

--- a/packages/core/data/abstract/Repository.base.ts
+++ b/packages/core/data/abstract/Repository.base.ts
@@ -92,13 +92,16 @@ export abstract class Repository {
 
   toAdjustUpdate(
     adjustments: Record<string, number>,
+    constraints?: { [field: string]: { min?: number; max?: number } },
     prefix = 'data',
   ): {
     UpdateExpression: string;
+    ConditionExpression?: string;
     ExpressionAttributeNames: Record<string, string>;
     ExpressionAttributeValues: Record<string, AttributeValue>;
   } {
     const parts: string[] = [];
+    const conditionParts: string[] = [];
     const expressionAttributeNames: Record<string, string> = {};
     const expressionAttributeValues: Record<string, unknown> = {};
 
@@ -107,19 +110,40 @@ export abstract class Repository {
     for (const field of Object.keys(adjustments)) {
       const namePlaceholder = `#${field}`;
       const valuePlaceholder = `:${field}`;
+      const fieldExpr = `if_not_exists(#${prefix}.${namePlaceholder}, :zero)`;
 
       parts.push(
-        `#${prefix}.${namePlaceholder} = if_not_exists(#${prefix}.${namePlaceholder}, :zero) + ${valuePlaceholder}`,
+        `#${prefix}.${namePlaceholder} = ${fieldExpr} + ${valuePlaceholder}`,
       );
 
       expressionAttributeNames[namePlaceholder] = field;
       expressionAttributeValues[valuePlaceholder] = adjustments[field];
+
+      // Build constraint conditions
+      if (constraints?.[field]) {
+        const constraint = constraints[field];
+        const adjustedExpr = `${fieldExpr} + ${valuePlaceholder}`;
+
+        if (constraint.min !== undefined) {
+          const minPlaceholder = `:${field}_min`;
+          conditionParts.push(`${adjustedExpr} >= ${minPlaceholder}`);
+          expressionAttributeValues[minPlaceholder] = constraint.min;
+        }
+        if (constraint.max !== undefined) {
+          const maxPlaceholder = `:${field}_max`;
+          conditionParts.push(`${adjustedExpr} <= ${maxPlaceholder}`);
+          expressionAttributeValues[maxPlaceholder] = constraint.max;
+        }
+      }
     }
 
     expressionAttributeValues[':zero'] = 0;
 
     return {
       UpdateExpression: `SET ${parts.join(', ')}`,
+      ...(conditionParts.length > 0 && {
+        ConditionExpression: conditionParts.join(' AND '),
+      }),
       ExpressionAttributeNames: expressionAttributeNames,
       ExpressionAttributeValues: marshall(expressionAttributeValues),
     };

--- a/packages/core/data/abstract/Repository.base.ts
+++ b/packages/core/data/abstract/Repository.base.ts
@@ -89,4 +89,39 @@ export abstract class Repository {
 
     return updateAttributes;
   }
+
+  toAdjustUpdate(
+    adjustments: Record<string, number>,
+    prefix = 'data',
+  ): {
+    UpdateExpression: string;
+    ExpressionAttributeNames: Record<string, string>;
+    ExpressionAttributeValues: Record<string, AttributeValue>;
+  } {
+    const parts: string[] = [];
+    const expressionAttributeNames: Record<string, string> = {};
+    const expressionAttributeValues: Record<string, unknown> = {};
+
+    expressionAttributeNames[`#${prefix}`] = prefix;
+
+    for (const field of Object.keys(adjustments)) {
+      const namePlaceholder = `#${field}`;
+      const valuePlaceholder = `:${field}`;
+
+      parts.push(
+        `#${prefix}.${namePlaceholder} = if_not_exists(#${prefix}.${namePlaceholder}, :zero) + ${valuePlaceholder}`,
+      );
+
+      expressionAttributeNames[namePlaceholder] = field;
+      expressionAttributeValues[valuePlaceholder] = adjustments[field];
+    }
+
+    expressionAttributeValues[':zero'] = 0;
+
+    return {
+      UpdateExpression: `SET ${parts.join(', ')}`,
+      ExpressionAttributeNames: expressionAttributeNames,
+      ExpressionAttributeValues: marshall(expressionAttributeValues),
+    };
+  }
 }

--- a/packages/core/data/abstract/Repository.base.ts
+++ b/packages/core/data/abstract/Repository.base.ts
@@ -126,38 +126,31 @@ export abstract class Repository {
       expressionAttributeNames[namePlaceholder] = field;
       expressionAttributeValues[valuePlaceholder] = adjustments[field];
 
-      // Build constraint conditions
+      // Build constraint conditions using pre-computed thresholds.
+      // ConditionExpression checks the current value against the threshold.
+      // UpdateExpression applies the delta. Both in a single atomic UpdateItem.
+      //
+      // For min with negative delta: currentValue >= (min + abs(delta))
+      // For max with positive delta: currentValue <= (max - delta)
+      //
+      // For dynamic minField/maxField: the service layer reads the entity's
+      // field value first, then passes it as a resolved static constraint.
       if (constraints?.[field]) {
         const constraint = constraints[field];
-        const adjustedExpr = `${fieldExpr} + ${valuePlaceholder}`;
+        const delta = adjustments[field];
+        const currentFieldExpr = `if_not_exists(#${prefix}.${namePlaceholder}, :zero)`;
 
-        // Static min
-        if (constraint.min !== undefined) {
-          const minPlaceholder = `:${field}_min`;
-          conditionParts.push(`${adjustedExpr} >= ${minPlaceholder}`);
-          expressionAttributeValues[minPlaceholder] = constraint.min;
+        // Static min — only check when decrementing
+        if (constraint.min !== undefined && delta < 0) {
+          const thresholdPlaceholder = `:${field}_min_threshold`;
+          conditionParts.push(`${currentFieldExpr} >= ${thresholdPlaceholder}`);
+          expressionAttributeValues[thresholdPlaceholder] = constraint.min - delta; // min + abs(delta)
         }
-        // Dynamic min — read from entity's own field
-        if (constraint.minField) {
-          const minFieldPlaceholder = `#${constraint.minField}`;
-          expressionAttributeNames[minFieldPlaceholder] = constraint.minField;
-          conditionParts.push(
-            `${adjustedExpr} >= if_not_exists(#${prefix}.${minFieldPlaceholder}, :zero)`,
-          );
-        }
-        // Static max
-        if (constraint.max !== undefined) {
-          const maxPlaceholder = `:${field}_max`;
-          conditionParts.push(`${adjustedExpr} <= ${maxPlaceholder}`);
-          expressionAttributeValues[maxPlaceholder] = constraint.max;
-        }
-        // Dynamic max — read from entity's own field
-        if (constraint.maxField) {
-          const maxFieldPlaceholder = `#${constraint.maxField}`;
-          expressionAttributeNames[maxFieldPlaceholder] = constraint.maxField;
-          conditionParts.push(
-            `${adjustedExpr} <= #${prefix}.${maxFieldPlaceholder}`,
-          );
+        // Static max — only check when incrementing
+        if (constraint.max !== undefined && delta > 0) {
+          const thresholdPlaceholder = `:${field}_max_threshold`;
+          conditionParts.push(`${currentFieldExpr} <= ${thresholdPlaceholder}`);
+          expressionAttributeValues[thresholdPlaceholder] = constraint.max - delta;
         }
       }
     }

--- a/packages/core/data/abstract/Repository.base.ts
+++ b/packages/core/data/abstract/Repository.base.ts
@@ -138,18 +138,21 @@ export abstract class Repository {
       if (constraints?.[field]) {
         const constraint = constraints[field];
         const delta = adjustments[field];
-        const currentFieldExpr = `if_not_exists(#${prefix}.${namePlaceholder}, :zero)`;
+        const currentFieldRef = `#${prefix}.${namePlaceholder}`;
 
         // Static min — only check when decrementing
+        // Condition: currentValue >= min + abs(delta)
+        // If field doesn't exist, condition fails (safe — can't withdraw from nothing)
         if (constraint.min !== undefined && delta < 0) {
           const thresholdPlaceholder = `:${field}_min_threshold`;
-          conditionParts.push(`${currentFieldExpr} >= ${thresholdPlaceholder}`);
-          expressionAttributeValues[thresholdPlaceholder] = constraint.min - delta; // min + abs(delta)
+          conditionParts.push(`${currentFieldRef} >= ${thresholdPlaceholder}`);
+          expressionAttributeValues[thresholdPlaceholder] = constraint.min - delta;
         }
         // Static max — only check when incrementing
+        // Condition: currentValue <= max - delta
         if (constraint.max !== undefined && delta > 0) {
           const thresholdPlaceholder = `:${field}_max_threshold`;
-          conditionParts.push(`${currentFieldExpr} <= ${thresholdPlaceholder}`);
+          conditionParts.push(`${currentFieldRef} <= ${thresholdPlaceholder}`);
           expressionAttributeValues[thresholdPlaceholder] = constraint.max - delta;
         }
       }

--- a/packages/core/data/abstract/Repository.base.ts
+++ b/packages/core/data/abstract/Repository.base.ts
@@ -92,7 +92,14 @@ export abstract class Repository {
 
   toAdjustUpdate(
     adjustments: Record<string, number>,
-    constraints?: { [field: string]: { min?: number; max?: number } },
+    constraints?: {
+      [field: string]: {
+        min?: number;
+        max?: number;
+        minField?: string;
+        maxField?: string;
+      };
+    },
     prefix = 'data',
   ): {
     UpdateExpression: string;
@@ -124,15 +131,33 @@ export abstract class Repository {
         const constraint = constraints[field];
         const adjustedExpr = `${fieldExpr} + ${valuePlaceholder}`;
 
+        // Static min
         if (constraint.min !== undefined) {
           const minPlaceholder = `:${field}_min`;
           conditionParts.push(`${adjustedExpr} >= ${minPlaceholder}`);
           expressionAttributeValues[minPlaceholder] = constraint.min;
         }
+        // Dynamic min — read from entity's own field
+        if (constraint.minField) {
+          const minFieldPlaceholder = `#${constraint.minField}`;
+          expressionAttributeNames[minFieldPlaceholder] = constraint.minField;
+          conditionParts.push(
+            `${adjustedExpr} >= if_not_exists(#${prefix}.${minFieldPlaceholder}, :zero)`,
+          );
+        }
+        // Static max
         if (constraint.max !== undefined) {
           const maxPlaceholder = `:${field}_max`;
           conditionParts.push(`${adjustedExpr} <= ${maxPlaceholder}`);
           expressionAttributeValues[maxPlaceholder] = constraint.max;
+        }
+        // Dynamic max — read from entity's own field
+        if (constraint.maxField) {
+          const maxFieldPlaceholder = `#${constraint.maxField}`;
+          expressionAttributeNames[maxFieldPlaceholder] = constraint.maxField;
+          conditionParts.push(
+            `${adjustedExpr} <= #${prefix}.${maxFieldPlaceholder}`,
+          );
         }
       }
     }

--- a/packages/core/docker-compose.test.yml
+++ b/packages/core/docker-compose.test.yml
@@ -3,7 +3,7 @@ version: "3.8"
 services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME:-localstack-main}"
-    image: localstack/localstack:latest
+    image: localstack/localstack:4.3.0
     ports:
       - "127.0.0.1:4566:4566"            # LocalStack Gateway
       - "127.0.0.1:4510-4559:4510-4559"  # external services port range

--- a/packages/core/helpers/test/test-utils.ts
+++ b/packages/core/helpers/test/test-utils.ts
@@ -27,6 +27,7 @@ export enum MockEntityType {
   PRODUCT = 'product',
   ADMIN = 'admin',
   COURSE = 'course',
+  WALLET = 'wallet',
 }
 
 // --- Configuration ---
@@ -95,6 +96,19 @@ export const createMockEntityConfig = () => ({
     name: MockEntityType.COURSE,
     displayName: 'Course',
     baseSchema: z.object({}), // Empty schema for placeholder
+  }),
+  [MockEntityType.WALLET]: createEntityConfig({
+    name: MockEntityType.WALLET,
+    displayName: 'Wallet',
+    baseSchema: z
+      .object({
+        balance: z.number(),
+        credits: z.number(),
+        minBalance: z.number(),
+        creditLimit: z.number(),
+        score: z.number(),
+      })
+      .partial(),
   }),
 });
 

--- a/packages/core/services/DependencyContainer.ts
+++ b/packages/core/services/DependencyContainer.ts
@@ -16,6 +16,7 @@ import { GetEntityByUniqueFieldValueController } from '../controllers/entity/get
 import { GetEntityController } from '../controllers/entity/get-entity.controller';
 import { ListEntitiesController } from '../controllers/entity/list-entities.controller';
 import { UpdateEntityController } from '../controllers/entity/update-entity.controller';
+import { AdjustEntityController } from '../controllers/entity/adjust-entity.controller';
 import { UpsertEntityController } from '../controllers/entity/upsert-entity.controller';
 import { CreateMutualController } from '../controllers/mutual/create-mutual.controller';
 import { DeleteMutualController } from '../controllers/mutual/delete-mutual.controller';
@@ -190,6 +191,13 @@ export class DependencyContainer {
   get updateEntityController(): UpdateEntityController {
     return this.createCachedInstance(
       UpdateEntityController,
+      this.entityService,
+    );
+  }
+
+  get adjustEntityController(): AdjustEntityController {
+    return this.createCachedInstance(
+      AdjustEntityController,
       this.entityService,
     );
   }

--- a/packages/core/services/entity.service.ts
+++ b/packages/core/services/entity.service.ts
@@ -106,13 +106,34 @@ export class EntityService {
     adjustments: Record<string, number>;
     accountId?: string;
   }) => {
-    const constraints = this.EntityConfig[entityType]?.adjustmentConstraints;
+    const rawConstraints = this.EntityConfig[entityType]?.adjustmentConstraints;
+
+    // Resolve dynamic minField/maxField to static values
+    let resolvedConstraints = rawConstraints;
+    if (rawConstraints) {
+      const hasDynamicFields = Object.values(rawConstraints).some(
+        (c: any) => c.minField || c.maxField,
+      );
+      if (hasDynamicFields) {
+        const currentEntity = await this.entityRepository.getEntity(entityType, entityId);
+        const data = currentEntity?.data ?? {};
+        resolvedConstraints = {};
+        for (const [field, constraint] of Object.entries(rawConstraints)) {
+          const resolved: { min?: number; max?: number } = {};
+          if ((constraint as any).min !== undefined) resolved.min = (constraint as any).min;
+          if ((constraint as any).max !== undefined) resolved.max = (constraint as any).max;
+          if ((constraint as any).minField) resolved.min = data[(constraint as any).minField] ?? 0;
+          if ((constraint as any).maxField) resolved.max = data[(constraint as any).maxField] ?? Number.MAX_SAFE_INTEGER;
+          resolvedConstraints[field] = resolved;
+        }
+      }
+    }
 
     const entity = await this.entityRepository.adjustEntity(
       entityType,
       entityId,
       adjustments,
-      constraints,
+      resolvedConstraints as any,
     );
 
     await this.publishEvent({

--- a/packages/core/services/entity.service.ts
+++ b/packages/core/services/entity.service.ts
@@ -106,10 +106,13 @@ export class EntityService {
     adjustments: Record<string, number>;
     accountId?: string;
   }) => {
+    const constraints = this.EntityConfig[entityType]?.adjustmentConstraints;
+
     const entity = await this.entityRepository.adjustEntity(
       entityType,
       entityId,
       adjustments,
+      constraints,
     );
 
     await this.publishEvent({

--- a/packages/core/services/entity.service.ts
+++ b/packages/core/services/entity.service.ts
@@ -95,6 +95,37 @@ export class EntityService {
     return entity;
   };
 
+  adjustEntity = async <T extends EntityType>({
+    entityType,
+    entityId,
+    adjustments,
+    accountId,
+  }: {
+    entityType: T;
+    entityId: string;
+    adjustments: Record<string, number>;
+    accountId?: string;
+  }) => {
+    const entity = await this.entityRepository.adjustEntity(
+      entityType,
+      entityId,
+      adjustments,
+    );
+
+    await this.publishEvent({
+      event: EVENT.CORE.ENTITY_UPDATED,
+      payload: {
+        entityType,
+        entityId,
+        data: entity.data,
+        updatedByAccountId: accountId,
+        publishedAt: entity.updatedAt || new Date().toISOString(),
+      },
+    });
+
+    return entity;
+  };
+
   updateEntity = async <T extends EntityType>({
     entityType,
     entityId,

--- a/packages/react/actions/core.action.ts
+++ b/packages/react/actions/core.action.ts
@@ -631,6 +631,84 @@ const initCoreActions = (
     }
   };
 
+  const adjustEntity = async <T extends Entity>(
+    entityType: T,
+    id: string,
+    adjustments: Record<string, number>,
+    opts: CommonOptions = {},
+  ) => {
+    const entityService = makeEntityService(entityType);
+    const onError = opts.onError ?? defaultOnError;
+
+    // Optimistically apply delta to local store
+    monoriseStore.setState(
+      produce((state) => {
+        const entity = state.entity[entityType]?.dataMap?.get(id);
+        if (entity) {
+          for (const [field, delta] of Object.entries(adjustments)) {
+            entity.data[field] = (entity.data[field] ?? 0) + delta;
+          }
+        }
+      }),
+      undefined,
+      `mr/entity/adjust/${entityType}/${id}`,
+    );
+
+    try {
+      const { data } = await entityService.adjustEntity(id, adjustments, opts);
+
+      // Reconcile with server response
+      monoriseStore.setState(
+        produce((state) => {
+          state.entity[entityType].dataMap.set(data.entityId, data);
+
+          // Propagate to mutual stores (same as editEntity)
+          for (const key of Object.keys(state.mutual)) {
+            const [_byEntity, _byId, _entityType] = key.split('/');
+            if ((_entityType as unknown as Entity) === entityType) {
+              const mutual = state.mutual[key].dataMap.get(id);
+              if (mutual) {
+                state.mutual[key].dataMap = new Map(
+                  state.mutual[key].dataMap,
+                ).set(id, { ...(mutual as any), data: data.data });
+              }
+            }
+          }
+
+          for (const key of Object.keys(state.mutual)) {
+            const [_byEntity, _byId] = key.split('/');
+            if ((_byEntity as unknown as Entity) === entityType && _byId === id) {
+              const newDataMap = new Map(state.mutual[key].dataMap);
+              for (const [entryId, mutual] of newDataMap) {
+                newDataMap.set(entryId, { ...(mutual as any), data: data.data });
+              }
+              state.mutual[key].dataMap = newDataMap;
+            }
+          }
+
+          // Propagate to tag stores
+          for (const tagKey of Object.keys(state.tag)) {
+            const [tagEntityType] = tagKey.split('/');
+            if ((tagEntityType as unknown as Entity) === entityType) {
+              if (state.tag[tagKey]?.dataMap?.has(id)) {
+                state.tag[tagKey].dataMap.set(id, data);
+              }
+            }
+          }
+        }),
+        undefined,
+        `mr/entity/adjust-reconcile/${entityType}/${id}`,
+      );
+
+      return { data };
+    } catch (err) {
+      const error: Error & { originalError?: unknown } =
+        err instanceof Error ? err : new Error('Unknown error occurred');
+      onError(error);
+      return { error };
+    }
+  };
+
   const deleteEntity = async <T extends Entity>(
     entityType: T,
     id: string,
@@ -1780,6 +1858,7 @@ const initCoreActions = (
     upsertEntity,
     getEntity,
     editEntity,
+    adjustEntity,
     deleteEntity,
     getMutual,
     updateLocalEntity,

--- a/packages/react/actions/core.action.ts
+++ b/packages/react/actions/core.action.ts
@@ -640,29 +640,15 @@ const initCoreActions = (
     const entityService = makeEntityService(entityType);
     const onError = opts.onError ?? defaultOnError;
 
-    // Optimistically apply delta to local store
-    monoriseStore.setState(
-      produce((state) => {
-        const entity = state.entity[entityType]?.dataMap?.get(id);
-        if (entity) {
-          for (const [field, delta] of Object.entries(adjustments)) {
-            entity.data[field] = (entity.data[field] ?? 0) + delta;
-          }
-        }
-      }),
-      undefined,
-      `mr/entity/adjust/${entityType}/${id}`,
-    );
-
     try {
       const { data } = await entityService.adjustEntity(id, adjustments, opts);
 
-      // Reconcile with server response
+      // Update local store with server response
       monoriseStore.setState(
         produce((state) => {
           state.entity[entityType].dataMap.set(data.entityId, data);
 
-          // Propagate to mutual stores (same as editEntity)
+          // Propagate to mutual stores
           for (const key of Object.keys(state.mutual)) {
             const [_byEntity, _byId, _entityType] = key.split('/');
             if ((_entityType as unknown as Entity) === entityType) {
@@ -697,11 +683,16 @@ const initCoreActions = (
           }
         }),
         undefined,
-        `mr/entity/adjust-reconcile/${entityType}/${id}`,
+        `mr/entity/adjust/${entityType}/${id}`,
       );
 
       return { data };
-    } catch (err) {
+    } catch (err: any) {
+      // Constraint violated — refetch entity to get latest state
+      if (err?.response?.status === 409) {
+        await getEntity(entityType, id, { forceFetch: true });
+      }
+
       const error: Error & { originalError?: unknown } =
         err instanceof Error ? err : new Error('Unknown error occurred');
       onError(error);

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -128,6 +128,7 @@ const {
   createEntity,
   upsertEntity,
   editEntity,
+  adjustEntity,
   updateLocalEntity,
   deleteEntity,
   getMutual,
@@ -179,6 +180,7 @@ export {
   createEntity,
   upsertEntity,
   editEntity,
+  adjustEntity,
   updateLocalEntity,
   deleteEntity,
   getMutual,
@@ -213,4 +215,5 @@ export type {
   DraftEntity,
   Entity,
   EntitySchemaMap,
+  NumericFields,
 } from '@monorise/base';

--- a/packages/react/lib/utils.ts
+++ b/packages/react/lib/utils.ts
@@ -45,7 +45,7 @@ export const getUniqueFieldStateKey = (
 };
 
 export const getEntityRequestKey = (
-  mode: 'create' | 'upsert' | 'edit' | 'delete' | 'get' | 'list' | 'search',
+  mode: 'create' | 'upsert' | 'edit' | 'adjust' | 'delete' | 'get' | 'list' | 'search',
   entityType: Entity,
   entityId?: string,
 ) => {

--- a/packages/react/services/core.service.ts
+++ b/packages/react/services/core.service.ts
@@ -55,7 +55,6 @@ export type CommonOptions = Partial<AxiosRequestConfig> & {
   limit?: number;
   requestKey?: string;
   onError?: (error: ApplicationRequestError | Error) => void;
-  limit?: number;
 };
 
 const initCoreService = (
@@ -218,6 +217,29 @@ const initCoreService = (
       values,
       {
         requestKey: getEntityRequestKey('edit', entityType, id),
+        isInterruptive: opts.isInterruptive ?? true,
+        feedback: {
+          loading: `Updating ${entityConfig[entityType].displayName}`,
+          success: `${entityConfig[entityType].displayName} updated`,
+          ...(opts.feedback || {}),
+        },
+      },
+    );
+  };
+
+  const adjustEntity = <T extends Entity>(
+    entityType: T,
+    id: string,
+    adjustments: Record<string, number>,
+    opts: CommonOptions = {},
+  ) => {
+    const { entityApiBaseUrl = ENTITY_API_BASE_URL } = options;
+    const entityConfig = monoriseStore.getState().config;
+    return axios.post<CreatedEntity<T>>(
+      opts.customUrl || `${entityApiBaseUrl}/${entityType}/${id}/adjust`,
+      adjustments,
+      {
+        requestKey: getEntityRequestKey('adjust', entityType, id),
         isInterruptive: opts.isInterruptive ?? true,
         feedback: {
           loading: `Updating ${entityConfig[entityType].displayName}`,
@@ -427,6 +449,11 @@ const initCoreService = (
       values: DraftEntity<T>,
       opts: CommonOptions = {},
     ) => editEntity(entityType, id, values, opts),
+    adjustEntity: (
+      id: string,
+      adjustments: Record<string, number>,
+      opts: CommonOptions = {},
+    ) => adjustEntity(entityType, id, adjustments, opts),
     deleteEntity: (id: string, opts: CommonOptions = {}) =>
       deleteEntity(entityType, id, opts),
   });

--- a/packages/react/services/core.service.ts
+++ b/packages/react/services/core.service.ts
@@ -55,6 +55,7 @@ export type CommonOptions = Partial<AxiosRequestConfig> & {
   limit?: number;
   requestKey?: string;
   onError?: (error: ApplicationRequestError | Error) => void;
+  entityId?: string;
 };
 
 const initCoreService = (
@@ -167,7 +168,7 @@ const initCoreService = (
     const entityConfig = monoriseStore.getState().config;
     return axios.post<CreatedEntity<T>>(
       opts.customUrl || `${entityApiBaseUrl}/${entityType}`,
-      values,
+      { ...values, ...(opts.entityId && { entityId: opts.entityId }) },
       {
         requestKey:
           opts.requestKey || getEntityRequestKey('create', entityType),

--- a/www/docs/architecture.md
+++ b/www/docs/architecture.md
@@ -62,6 +62,7 @@ The default Hono API exposes the following routes under `/core`. All entity rout
 | `PUT` | `/entity/:entityType/:entityId` | Upsert entity (full replacement) |
 | `PATCH` | `/entity/:entityType/:entityId` | Update entity (partial) |
 | `DELETE` | `/entity/:entityType/:entityId` | Delete entity |
+| `POST` | `/entity/:entityType/:entityId/adjust` | Atomic numeric adjustment (body: `{ field: delta }`) |
 
 ### Mutual endpoints
 

--- a/www/docs/concepts/entities.md
+++ b/www/docs/concepts/entities.md
@@ -55,6 +55,7 @@ export default config;
 | `uniqueFields` | `string[]` | No | Fields that must be unique per entity type |
 | `mutual` | `object` | No | Mutual relationship configuration (see [Mutuals](/concepts/mutuals)) |
 | `tags` | `array` | No | Tag access patterns (see [Tags](/concepts/tags)) |
+| `adjustmentConstraints` | `object` | No | Bounds for numeric fields when using [`adjustEntity`](/react#adjustentity) |
 
 ## Unique fields
 

--- a/www/docs/react.md
+++ b/www/docs/react.md
@@ -325,7 +325,33 @@ await adjustEntity(Entity.MONTHLY_SUMMARY, summaryId, {
 
 **Type safety**: Only accepts numeric fields from the entity schema. Passing a string field results in a TypeScript error.
 
-**Optimistic update**: The local store is updated immediately with the delta before the API responds. Once the server responds, the store reconciles with the actual values.
+**No optimistic update**: Unlike `editEntity`, the local cache is only updated after the server confirms success. This is because adjustments may fail (constraint violations) or produce different results than expected (concurrent adjustments).
+
+**Constraints**: Define `adjustmentConstraints` in your entity config to enforce bounds. If an adjustment would violate a constraint, the operation is rejected and the entity is automatically refetched to get the latest state.
+
+```ts
+// Entity config
+const config = createEntityConfig({
+  name: 'wallet',
+  baseSchema,
+  adjustmentConstraints: {
+    balance: { min: 0 },             // balance cannot go below 0
+    credits: { min: 0, max: 10000 }, // credits must stay between 0 and 10,000
+  },
+});
+
+// This succeeds (balance: 100 → 70)
+await adjustEntity(Entity.WALLET, id, { balance: -30 });
+
+// This fails with ADJUSTMENT_CONSTRAINT_VIOLATED (70 - 80 = -10 < 0)
+const { error } = await adjustEntity(Entity.WALLET, id, { balance: -80 });
+if (error) {
+  // entity is automatically refetched with latest state
+  // show "Insufficient balance" to user
+}
+```
+
+Constraints are enforced at the database level — they cannot be bypassed by the frontend.
 
 **Event publishing**: Publishes `ENTITY_UPDATED` event, so tag and replication processors keep denormalized data in sync — same as `editEntity`.
 

--- a/www/docs/react.md
+++ b/www/docs/react.md
@@ -279,6 +279,25 @@ const entityState = useEntityState(Entity.USER);
 | `getEntity(entityType, id)` | Fetch single entity (non-hook). |
 | `listMoreEntities(entityType, opts?)` | Load next page of entities. |
 
+### `editEntity`
+
+Partially update an entity by setting fields to exact values.
+
+```ts
+import { editEntity } from 'monorise/react';
+
+await editEntity(Entity.USER, userId, {
+  name: 'Alice Smith',
+  role: 'admin',
+});
+```
+
+Only the fields you pass are updated — other fields remain unchanged. The updated entity propagates to mutual and tag stores automatically.
+
+::: tip
+If you need to increment or decrement a numeric field (e.g., a counter or running total), use [`adjustEntity`](#adjustentity) instead. `editEntity` sets the field to the value you provide, which can cause data loss if multiple updates happen concurrently.
+:::
+
 ### `adjustEntity`
 
 Safely increment or decrement numeric fields on an entity. Unlike `editEntity` which sets a field to a specific value, `adjustEntity` adds or subtracts a delta — meaning multiple concurrent adjustments never overwrite each other.

--- a/www/docs/react.md
+++ b/www/docs/react.md
@@ -273,10 +273,36 @@ const entityState = useEntityState(Entity.USER);
 |--------|-------------|
 | `createEntity(entityType, data, opts?)` | Create entity on server. Returns `{ data }` or `{ error }`. |
 | `editEntity(entityType, id, data, opts?)` | Partial update entity. Returns `{ data }` or `{ error }`. |
+| `adjustEntity(entityType, id, adjustments, opts?)` | Atomic numeric adjustment. Race-condition safe. Returns `{ data }` or `{ error }`. |
 | `upsertEntity(entityType, id, data, opts?)` | Insert or full replace. Returns `{ data }` or `{ error }`. |
 | `deleteEntity(entityType, id, opts?)` | Delete entity. Returns `{ data }` or `{ error }`. |
 | `getEntity(entityType, id)` | Fetch single entity (non-hook). |
 | `listMoreEntities(entityType, opts?)` | Load next page of entities. |
+
+### `adjustEntity`
+
+Atomically adjust numeric fields on an entity. Uses DynamoDB's native arithmetic (`SET field = field + delta`) — safe for concurrent writes with no read-modify-write race conditions.
+
+```ts
+import { adjustEntity } from 'monorise/react';
+
+// Increment sales by $50.00 and count by 1
+await adjustEntity(Entity.MONTHLY_SUMMARY, summaryId, {
+  totalSales: 5000,
+  count: 1,
+});
+
+// Decrement (use negative values)
+await adjustEntity(Entity.MONTHLY_SUMMARY, summaryId, {
+  totalRefunds: -2000,
+});
+```
+
+**Type safety**: Only accepts numeric fields from the entity schema. Passing a string field results in a TypeScript error.
+
+**Optimistic update**: The local store is updated immediately with the delta before the API responds. Once the server responds, the store reconciles with the actual values.
+
+**Event publishing**: Publishes `ENTITY_UPDATED` event, triggering tag and replication processors to keep denormalized data in sync.
 
 ### Mutual actions
 

--- a/www/docs/react.md
+++ b/www/docs/react.md
@@ -273,7 +273,7 @@ const entityState = useEntityState(Entity.USER);
 |--------|-------------|
 | `createEntity(entityType, data, opts?)` | Create entity on server. Returns `{ data }` or `{ error }`. |
 | `editEntity(entityType, id, data, opts?)` | Partial update entity. Returns `{ data }` or `{ error }`. |
-| `adjustEntity(entityType, id, adjustments, opts?)` | Atomic numeric adjustment. Race-condition safe. Returns `{ data }` or `{ error }`. |
+| `adjustEntity(entityType, id, adjustments, opts?)` | Safely increment/decrement numeric fields. Returns `{ data }` or `{ error }`. |
 | `upsertEntity(entityType, id, data, opts?)` | Insert or full replace. Returns `{ data }` or `{ error }`. |
 | `deleteEntity(entityType, id, opts?)` | Delete entity. Returns `{ data }` or `{ error }`. |
 | `getEntity(entityType, id)` | Fetch single entity (non-hook). |
@@ -281,7 +281,13 @@ const entityState = useEntityState(Entity.USER);
 
 ### `adjustEntity`
 
-Atomically adjust numeric fields on an entity. Uses DynamoDB's native arithmetic (`SET field = field + delta`) — safe for concurrent writes with no read-modify-write race conditions.
+Safely increment or decrement numeric fields on an entity. Unlike `editEntity` which sets a field to a specific value, `adjustEntity` adds or subtracts a delta — meaning multiple concurrent adjustments never overwrite each other.
+
+**Why not `editEntity`?** Imagine two requests try to increment a counter from 100 at the same time:
+- With `editEntity`: both read 100, both write 101. You lose one increment.
+- With `adjustEntity`: both send "+1". The result is 102. No data loss.
+
+Use `adjustEntity` for counters, running totals, scores, or any field that multiple sources update concurrently.
 
 ```ts
 import { adjustEntity } from 'monorise/react';
@@ -302,7 +308,7 @@ await adjustEntity(Entity.MONTHLY_SUMMARY, summaryId, {
 
 **Optimistic update**: The local store is updated immediately with the delta before the API responds. Once the server responds, the store reconciles with the actual values.
 
-**Event publishing**: Publishes `ENTITY_UPDATED` event, triggering tag and replication processors to keep denormalized data in sync.
+**Event publishing**: Publishes `ENTITY_UPDATED` event, so tag and replication processors keep denormalized data in sync — same as `editEntity`.
 
 ### Mutual actions
 

--- a/www/docs/react.md
+++ b/www/docs/react.md
@@ -335,8 +335,9 @@ const config = createEntityConfig({
   name: 'wallet',
   baseSchema,
   adjustmentConstraints: {
-    balance: { min: 0 },             // balance cannot go below 0
-    credits: { min: 0, max: 10000 }, // credits must stay between 0 and 10,000
+    // Static: same for all wallets
+    balance: { min: 0 },
+    credits: { min: 0, max: 10000 },
   },
 });
 
@@ -350,6 +351,29 @@ if (error) {
   // show "Insufficient balance" to user
 }
 ```
+
+**Dynamic constraints** — use `minField`/`maxField` to read the constraint value from the entity's own data. This lets each entity instance have different limits:
+
+```ts
+const config = createEntityConfig({
+  name: 'wallet',
+  baseSchema: z.object({
+    balance: z.number(),
+    minBalance: z.number(), // each wallet stores its own minimum
+  }).partial(),
+  adjustmentConstraints: {
+    balance: { minField: 'minBalance' },
+  },
+});
+
+// Wallet A: can go down to $0
+createEntity(Entity.WALLET, { balance: 10000, minBalance: 0 });
+
+// Wallet B: must keep at least $10
+createEntity(Entity.WALLET, { balance: 10000, minBalance: 1000 });
+```
+
+`minField`/`maxField` only accept numeric field names from the schema — TypeScript will reject non-numeric fields.
 
 Constraints are enforced at the database level — they cannot be bypassed by the frontend.
 

--- a/www/docs/react.md
+++ b/www/docs/react.md
@@ -272,7 +272,7 @@ const entityState = useEntityState(Entity.USER);
 | Action | Description |
 |--------|-------------|
 | `createEntity(entityType, data, opts?)` | Create entity on server. Returns `{ data }` or `{ error }`. |
-| `editEntity(entityType, id, data, opts?)` | Partial update entity. Returns `{ data }` or `{ error }`. |
+| `editEntity(entityType, id, data, opts?)` | Partial update entity (sets fields to exact values). For incrementing/decrementing numbers, use [`adjustEntity`](#adjustentity) instead. Returns `{ data }` or `{ error }`. |
 | `adjustEntity(entityType, id, adjustments, opts?)` | Safely increment/decrement numeric fields. Returns `{ data }` or `{ error }`. |
 | `upsertEntity(entityType, id, data, opts?)` | Insert or full replace. Returns `{ data }` or `{ error }`. |
 | `deleteEntity(entityType, id, opts?)` | Delete entity. Returns `{ data }` or `{ error }`. |


### PR DESCRIPTION
## Summary

Introduces `adjustEntity` across the full stack for race-condition-free numeric field updates. Uses DynamoDB's native arithmetic expressions (`SET field = field + delta`) instead of read-modify-write cycles, making it safe for concurrent writes.

## Use cases

- **Counters & accumulators**: Page views, transaction counts, inventory levels
- **Real-time metrics**: Running totals, aggregated scores, cumulative amounts
- **Financial summaries**: Incrementally update sales/refund totals as transactions flow in

## API

### Backend
```
POST /core/entity/:entityType/:entityId/adjust
Body: { "totalSales": 5000, "count": 1 }
```

All values must be numbers. Positive values increment, negative values decrement. Fields that don't exist yet are initialized to 0 before adjustment (`if_not_exists`).

### React SDK
```ts
import { adjustEntity } from 'monorise/react';

await adjustEntity(Entity.MONTHLY_SUMMARY, summaryId, {
  totalSales: 5000,   // +$50.00
  count: 1,           // +1 transaction
  totalRefunds: -200, // -$2.00 (decrement)
});
```

### Type safety
```ts
// NumericFields<T> extracts only number-typed keys
type NumericFields<T> = {
  [K in keyof T as T[K] extends number ? K : never]?: number;
};

// TypeScript error: merchantId is string, not number
adjustEntity(Entity.SUMMARY, id, { merchantId: 'abc' }); // ✗
```

## Implementation

| Layer | What |
|-------|------|
| `@monorise/base` | `NumericFields<T>` utility type |
| `@monorise/core` | `toAdjustUpdate()` for DynamoDB arithmetic expressions, `adjustEntity` in repository + service + controller, new route |
| `@monorise/react` | `adjustEntity` action with optimistic store update + propagation to mutual/tag stores |
| Docs | React SDK reference + API endpoint docs |

## Behavior

- **DynamoDB expression**: `SET #data.#field = if_not_exists(#data.#field, :zero) + :delta`
- **Events**: Publishes `ENTITY_UPDATED` → triggers tag + replication processors
- **Optimistic**: Local Zustand store updated immediately with delta, reconciled with server response
- **Propagation**: Updated entity propagates to mutual and tag stores (same as `editEntity`)

## Demo

https://github.com/user-attachments/assets/6f00ea9f-396c-446d-b979-1d59f6b9286d

AdjustEntity atomicity

## Test plan
- [ ] `adjustEntity` with positive values increments fields
- [ ] `adjustEntity` with negative values decrements fields
- [ ] Concurrent adjustments don't lose data (DynamoDB atomic)
- [ ] `ENTITY_UPDATED` event published after adjustment
- [ ] React store updates optimistically then reconciles
- [ ] Non-numeric fields rejected with 400
- [ ] Non-existent fields initialized to 0 before adjustment