### PR TITLE
Support array fields in searchableFields

### DIFF
--- a/.changeset/search-array-fields.md
+++ b/.changeset/search-array-fields.md
@@ -1,0 +1,5 @@
+---
+"@monorise/core": patch
+---
+
+Support array fields in searchableFields and normalize dashes/underscores to spaces for better search matching

--- a/packages/core/data/Entity.ts
+++ b/packages/core/data/Entity.ts
@@ -767,9 +767,15 @@ export class EntityRepository extends Repository {
 
     for (const item of results.items) {
       const searchTerm = (searchableFields ?? [])
-        .map((field) =>
-          (item.data as Record<string, any>)[field]?.toLowerCase(),
-        )
+        .map((field) => {
+          const value = (item.data as Record<string, unknown>)[field];
+          if (Array.isArray(value)) {
+            return value
+              .map((v) => String(v).replace(/[-_]/g, ' ').toLowerCase())
+              .join(' ');
+          }
+          return String(value ?? '').replace(/[-_]/g, ' ').toLowerCase();
+        })
         .join(' ');
       const isMatched = queryRegex.test(searchTerm);
       if (isMatched) {


### PR DESCRIPTION
## Summary
- Handle array values in `searchableFields` by flattening elements into the search string
- Normalize dashes and underscores to spaces for all searchable fields, enabling searches like "shah alam" to match "shah-alam"