### PR TITLE
Websocket #3 - feat(websocket): add feed subscription broadcast resolution

### DIFF
--- a/.changeset/entity-feed-subscriptions.md
+++ b/.changeset/entity-feed-subscriptions.md
@@ -1,0 +1,12 @@
+---
+"@monorise/core": minor
+---
+
+Add feed subscription broadcast resolution via mutual graph traversal.
+
+- `broadcastToFeedSubscribers()` resolves affected feed subscribers when changes occur
+- Traverses mutual relationships to find connected entities with feed subscriptions
+- Filters by feedTypes whitelist, deduplicates per-connection
+- ConsistentRead on all broadcast subscriber queries
+- Broadcast always runs feed resolution (not skipped when no direct subscribers)
+- $disconnect cleans up all subscription records via R1 GSI

--- a/packages/core/processors/websocket-processor.ts
+++ b/packages/core/processors/websocket-processor.ts
@@ -254,7 +254,7 @@ export const disconnect = async (
                 TableName: tableName,
                 Key: { PK: pk, SK: sk },
               }),
-            ).catch(() => {}),
+            ).catch((e) => console.warn('Failed to delete subscription on disconnect:', e)),
           );
         }
       }
@@ -537,10 +537,8 @@ export const $default = async (
 export const broadcast: DynamoDBStreamHandler = async (
   event: DynamoDBStreamEvent,
 ) => {
-  console.log('[WS_BROADCAST] Handler invoked, records:', event.Records.length);
   const tableName = getTableName();
   const wsEndpoint = getWsEndpoint();
-  console.log('[WS_BROADCAST] table:', tableName, 'wsEndpoint:', wsEndpoint);
   const managementApi = new ApiGatewayManagementApiClient({
     endpoint: wsEndpoint,
   });
@@ -560,13 +558,12 @@ export const broadcast: DynamoDBStreamHandler = async (
     const pk = image.PK?.S || '';
     const sk = image.SK?.S || '';
 
-    // Skip connection/subscription/ticket records
-    if (pk.startsWith('CONN#') || pk.startsWith('SUB#') || pk.startsWith('SUB:') || pk.startsWith('TICKET#') || pk.startsWith('LIST#') || pk.startsWith('MUTUAL#') || pk.startsWith('UNIQUE#') || pk.startsWith('EMAIL#')) continue;
-
-    console.log('[WS_BROADCAST] Processing record PK:', pk, 'SK:', sk);
-
+    // Only process entity/mutual records (format: entityType#entityId)
+    // Skip all other record types (CONN#, SUB#, TICKET#, LIST#, MUTUAL#, etc.)
     const pkParts = pk.split('#');
     if (pkParts.length < 2) continue;
+    const firstPart = pkParts[0];
+    if (firstPart === firstPart.toUpperCase() || firstPart.includes(':')) continue;
 
     const entityType = pkParts[0];
     const entityId = pkParts[1];
@@ -711,40 +708,39 @@ async function broadcastToSubscribers(
 
   const messageData = JSON.stringify(message);
 
-  for (const subscriber of subscribersResult.Items) {
-    const subscriberConnectionId = subscriber.connectionId as string;
-
-    // Skip excluded connection (e.g., sender of ephemeral message)
-    if (excludeConnectionId && subscriberConnectionId === excludeConnectionId) {
-      continue;
-    }
-
-    try {
-      await managementApi.send(
-        new PostToConnectionCommand({
-          ConnectionId: subscriberConnectionId,
-          Data: messageData,
-        }),
-      );
-    } catch (error: unknown) {
-      // Clean up stale connections
-      if (
-        error instanceof Error &&
-        (error.message?.includes('GoneException') ||
-          error.message?.includes('410'))
-      ) {
-        await docClient.send(
-          new DeleteCommand({
-            TableName: tableName,
-            Key: {
-              PK: subKey,
-              SK: `CONN#${subscriberConnectionId}`,
-            },
+  const sends = subscribersResult.Items
+    .filter((subscriber) => {
+      const id = subscriber.connectionId as string;
+      return !excludeConnectionId || id !== excludeConnectionId;
+    })
+    .map(async (subscriber) => {
+      const subscriberConnectionId = subscriber.connectionId as string;
+      try {
+        await managementApi.send(
+          new PostToConnectionCommand({
+            ConnectionId: subscriberConnectionId,
+            Data: messageData,
           }),
         );
+      } catch (error: unknown) {
+        const isGone =
+          (error as any)?.name === 'GoneException' ||
+          (error as any)?.$metadata?.httpStatusCode === 410;
+        if (isGone) {
+          await docClient.send(
+            new DeleteCommand({
+              TableName: tableName,
+              Key: {
+                PK: subKey,
+                SK: `CONN#${subscriberConnectionId}`,
+              },
+            }),
+          ).catch((e) => console.warn('Failed to clean up stale subscription:', e));
+        }
       }
-    }
-  }
+    });
+
+  await Promise.allSettled(sends);
 }
 
 /**
@@ -774,11 +770,10 @@ async function broadcastToFeedSubscribers(
       TableName: tableName,
       KeyConditionExpression: 'PK = :pk',
       ExpressionAttributeValues: { ':pk': pk },
+      ProjectionExpression: 'SK',
       ConsistentRead: true,
     }),
   );
-
-  console.log('[FEED_BROADCAST] Query PK:', pk, 'found items:', mutualsResult.Items?.length || 0);
 
   if (!mutualsResult.Items?.length) return;
 
@@ -787,7 +782,6 @@ async function broadcastToFeedSubscribers(
 
   for (const item of mutualsResult.Items) {
     const sk = item.SK as string;
-    console.log('[FEED_BROADCAST] Item SK:', sk);
     if (!sk || sk === '#METADATA#' || sk.startsWith('#')) continue;
 
     // SK format: entityType#entityId
@@ -801,9 +795,6 @@ async function broadcastToFeedSubscribers(
 
   // Also check the entity itself as a feed subscriber
   connectedEntities.add(`${byEntityType}:${byEntityId}`);
-
-  console.log('[FEED_BROADCAST] Connected entities:', Array.from(connectedEntities));
-  console.log('[FEED_BROADCAST] Changed entity type:', changedEntityType);
 
   // Step 2: For each connected entity, check if they have a feed subscription
   const sentConnections = new Set<string>();
@@ -821,14 +812,11 @@ async function broadcastToFeedSubscribers(
       }),
     );
 
-    console.log('[FEED_BROADCAST] Feed sub query:', feedSubKey, 'found:', feedSubsResult.Items?.length || 0);
-
     if (!feedSubsResult.Items?.length) continue;
 
     for (const feedSub of feedSubsResult.Items) {
       const feedTypes = feedSub.feedTypes as string[] | undefined;
       const connectionId = feedSub.connectionId as string;
-      console.log('[FEED_BROADCAST] Feed sub:', { connectionId, feedTypes, changedEntityType, pass: !feedTypes || feedTypes.includes(changedEntityType) });
 
       // Check if the changed entity type is in the feed's allowed types
       if (feedTypes && !feedTypes.includes(changedEntityType)) continue;
@@ -845,11 +833,10 @@ async function broadcastToFeedSubscribers(
           }),
         );
       } catch (error: unknown) {
-        if (
-          error instanceof Error &&
-          (error.message?.includes('GoneException') ||
-            error.message?.includes('410'))
-        ) {
+        const isGone =
+          (error as any)?.name === 'GoneException' ||
+          (error as any)?.$metadata?.httpStatusCode === 410;
+        if (isGone) {
           await docClient.send(
             new DeleteCommand({
               TableName: tableName,
@@ -858,7 +845,7 @@ async function broadcastToFeedSubscribers(
                 SK: `${CONN_PREFIX}${connectionId}`,
               },
             }),
-          );
+          ).catch((e) => console.warn('Failed to clean up stale feed subscription:', e));
         }
       }
     }

--- a/packages/core/processors/websocket-processor.ts
+++ b/packages/core/processors/websocket-processor.ts
@@ -17,6 +17,7 @@ import type {
   DynamoDBStreamHandler,
 } from 'aws-lambda';
 import { ulid } from 'ulid';
+import { ENTITY_REPLICATION_INDEX } from '../configs/service.config';
 
 // $connect event includes query params and headers, but the base WebSocket type doesn't model them
 type WebSocketConnectEvent = APIGatewayProxyWebsocketEventV2 & {
@@ -66,6 +67,7 @@ interface ServerMessage {
 }
 
 const getTableName = () => process.env.CORE_TABLE || '';
+
 
 const getWsEndpoint = () => process.env.WEBSOCKET_MANAGEMENT_ENDPOINT || '';
 
@@ -212,6 +214,7 @@ export const connect = async (
 
 /**
  * $disconnect handler
+ * Cleans up connection record and all associated subscription records.
  */
 export const disconnect = async (
   event: APIGatewayProxyWebsocketEventV2,
@@ -224,19 +227,53 @@ export const disconnect = async (
   const tableName = getTableName();
 
   try {
-    // Delete connection record
-    await docClient.send(
-      new DeleteCommand({
+    // Read connection record to find associated subscriptions
+    // Query R1 GSI to find all subscription records for this connection
+    const subscriptionsResult = await docClient.send(
+      new QueryCommand({
         TableName: tableName,
-        Key: {
-          PK: `${CONN_PREFIX}${connectionId}`,
-          SK: METADATA_SK,
+        IndexName: ENTITY_REPLICATION_INDEX,
+        KeyConditionExpression: 'R1PK = :r1pk',
+        ExpressionAttributeValues: {
+          ':r1pk': `${CONN_PREFIX}${connectionId}`,
         },
       }),
     );
 
-    // Note: Subscriptions are automatically cleaned up via DynamoDB Stream
-    // when connection records are deleted
+    const deletePromises: Promise<any>[] = [];
+
+    // Delete all subscription records found via R1 GSI
+    if (subscriptionsResult.Items?.length) {
+      for (const item of subscriptionsResult.Items) {
+        const pk = item.PK as string;
+        const sk = item.SK as string;
+        if (pk && sk) {
+          deletePromises.push(
+            docClient.send(
+              new DeleteCommand({
+                TableName: tableName,
+                Key: { PK: pk, SK: sk },
+              }),
+            ).catch(() => {}),
+          );
+        }
+      }
+    }
+
+    // Delete connection record
+    deletePromises.push(
+      docClient.send(
+        new DeleteCommand({
+          TableName: tableName,
+          Key: {
+            PK: `${CONN_PREFIX}${connectionId}`,
+            SK: METADATA_SK,
+          },
+        }),
+      ),
+    );
+
+    await Promise.all(deletePromises);
 
     return { statusCode: 200, body: 'Disconnected' };
   } catch (error) {
@@ -293,6 +330,7 @@ export const $default = async (
               },
             }),
           );
+
         }
         // Mutual type subscription
         else if (byEntityType && byEntityId && mutualEntityType) {
@@ -314,6 +352,7 @@ export const $default = async (
               },
             }),
           );
+
         }
         // Ephemeral channel subscription
         else if (channel) {
@@ -333,6 +372,7 @@ export const $default = async (
               },
             }),
           );
+
         } else {
           return { statusCode: 400, body: 'Invalid subscription parameters' };
         }
@@ -497,8 +537,10 @@ export const $default = async (
 export const broadcast: DynamoDBStreamHandler = async (
   event: DynamoDBStreamEvent,
 ) => {
+  console.log('[WS_BROADCAST] Handler invoked, records:', event.Records.length);
   const tableName = getTableName();
   const wsEndpoint = getWsEndpoint();
+  console.log('[WS_BROADCAST] table:', tableName, 'wsEndpoint:', wsEndpoint);
   const managementApi = new ApiGatewayManagementApiClient({
     endpoint: wsEndpoint,
   });
@@ -518,8 +560,10 @@ export const broadcast: DynamoDBStreamHandler = async (
     const pk = image.PK?.S || '';
     const sk = image.SK?.S || '';
 
-    // Skip connection/subscription records
-    if (pk.startsWith('CONN#') || pk.startsWith('SUB:')) continue;
+    // Skip connection/subscription/ticket records
+    if (pk.startsWith('CONN#') || pk.startsWith('SUB#') || pk.startsWith('SUB:') || pk.startsWith('TICKET#') || pk.startsWith('LIST#') || pk.startsWith('MUTUAL#') || pk.startsWith('UNIQUE#') || pk.startsWith('EMAIL#')) continue;
+
+    console.log('[WS_BROADCAST] Processing record PK:', pk, 'SK:', sk);
 
     const pkParts = pk.split('#');
     if (pkParts.length < 2) continue;
@@ -546,32 +590,32 @@ export const broadcast: DynamoDBStreamHandler = async (
           }),
         );
 
-        if (!subscribersResult.Items?.length) continue;
+        if (subscribersResult.Items?.length) {
+          let eventType: ServerMessage['type'];
+          if (isInsert) eventType = 'mutual.created';
+          else if (isModify) eventType = 'mutual.updated';
+          else eventType = 'mutual.deleted';
 
-        let eventType: ServerMessage['type'];
-        if (isInsert) eventType = 'mutual.created';
-        else if (isModify) eventType = 'mutual.updated';
-        else eventType = 'mutual.deleted';
+          const message: ServerMessage = {
+            type: eventType,
+            id: ulid(),
+            payload: {
+              byEntityType: entityType,
+              byEntityId,
+              mutualEntityType,
+              entityId: skParts[1],
+              data: isRemove ? undefined : unmarshall(image as Record<string, any>),
+            },
+          };
 
-        const message: ServerMessage = {
-          type: eventType,
-          id: ulid(),
-          payload: {
-            byEntityType: entityType,
-            byEntityId,
-            mutualEntityType,
-            entityId: skParts[1],
-            data: isRemove ? undefined : unmarshall(image as Record<string, any>),
-          },
-        };
-
-        await broadcastToSubscribers(
-          managementApi,
-          docClient,
-          tableName,
-          subKey,
-          message,
-        );
+          await broadcastToSubscribers(
+            managementApi,
+            docClient,
+            tableName,
+            subKey,
+            message,
+          );
+        }
       } else {
         // Entity type broadcast
         const subKey = `${SUB_ENTITY_TYPE}${entityType}`;
@@ -585,30 +629,30 @@ export const broadcast: DynamoDBStreamHandler = async (
           }),
         );
 
-        if (!subscribersResult.Items?.length) continue;
+        if (subscribersResult.Items?.length) {
+          let eventType: ServerMessage['type'];
+          if (isInsert) eventType = 'entity.created';
+          else if (isModify) eventType = 'entity.updated';
+          else eventType = 'entity.deleted';
 
-        let eventType: ServerMessage['type'];
-        if (isInsert) eventType = 'entity.created';
-        else if (isModify) eventType = 'entity.updated';
-        else eventType = 'entity.deleted';
+          const message: ServerMessage = {
+            type: eventType,
+            id: ulid(),
+            payload: {
+              entityType,
+              entityId,
+              data: isRemove ? undefined : unmarshall(image as Record<string, any>),
+            },
+          };
 
-        const message: ServerMessage = {
-          type: eventType,
-          id: ulid(),
-          payload: {
-            entityType,
-            entityId,
-            data: isRemove ? undefined : unmarshall(image as Record<string, any>),
-          },
-        };
-
-        await broadcastToSubscribers(
-          managementApi,
-          docClient,
-          tableName,
-          subKey,
-          message,
-        );
+          await broadcastToSubscribers(
+            managementApi,
+            docClient,
+            tableName,
+            subKey,
+            message,
+          );
+        }
       }
       // Feed broadcast: resolve feed subscribers connected to this entity
       await broadcastToFeedSubscribers(
@@ -734,6 +778,8 @@ async function broadcastToFeedSubscribers(
     }),
   );
 
+  console.log('[FEED_BROADCAST] Query PK:', pk, 'found items:', mutualsResult.Items?.length || 0);
+
   if (!mutualsResult.Items?.length) return;
 
   // Collect unique connected entities (the "other side" of the mutual)
@@ -741,6 +787,7 @@ async function broadcastToFeedSubscribers(
 
   for (const item of mutualsResult.Items) {
     const sk = item.SK as string;
+    console.log('[FEED_BROADCAST] Item SK:', sk);
     if (!sk || sk === '#METADATA#' || sk.startsWith('#')) continue;
 
     // SK format: entityType#entityId
@@ -754,6 +801,9 @@ async function broadcastToFeedSubscribers(
 
   // Also check the entity itself as a feed subscriber
   connectedEntities.add(`${byEntityType}:${byEntityId}`);
+
+  console.log('[FEED_BROADCAST] Connected entities:', Array.from(connectedEntities));
+  console.log('[FEED_BROADCAST] Changed entity type:', changedEntityType);
 
   // Step 2: For each connected entity, check if they have a feed subscription
   const sentConnections = new Set<string>();
@@ -771,11 +821,14 @@ async function broadcastToFeedSubscribers(
       }),
     );
 
+    console.log('[FEED_BROADCAST] Feed sub query:', feedSubKey, 'found:', feedSubsResult.Items?.length || 0);
+
     if (!feedSubsResult.Items?.length) continue;
 
     for (const feedSub of feedSubsResult.Items) {
       const feedTypes = feedSub.feedTypes as string[] | undefined;
       const connectionId = feedSub.connectionId as string;
+      console.log('[FEED_BROADCAST] Feed sub:', { connectionId, feedTypes, changedEntityType, pass: !feedTypes || feedTypes.includes(changedEntityType) });
 
       // Check if the changed entity type is in the feed's allowed types
       if (feedTypes && !feedTypes.includes(changedEntityType)) continue;

--- a/packages/core/processors/websocket-processor.ts
+++ b/packages/core/processors/websocket-processor.ts
@@ -537,6 +537,7 @@ export const broadcast: DynamoDBStreamHandler = async (
             TableName: tableName,
             KeyConditionExpression: 'PK = :pk',
             ExpressionAttributeValues: { ':pk': subKey },
+            ConsistentRead: true,
           }),
         );
 
@@ -575,6 +576,7 @@ export const broadcast: DynamoDBStreamHandler = async (
             TableName: tableName,
             KeyConditionExpression: 'PK = :pk',
             ExpressionAttributeValues: { ':pk': subKey },
+            ConsistentRead: true,
           }),
         );
 
@@ -603,6 +605,36 @@ export const broadcast: DynamoDBStreamHandler = async (
           message,
         );
       }
+      // Feed broadcast: resolve feed subscribers connected to this entity
+      await broadcastToFeedSubscribers(
+        managementApi,
+        docClient,
+        tableName,
+        entityType,
+        entityId,
+        isMutual ? sk.split('#')[0] : entityType, // the changed entity type
+        isMutual
+          ? {
+              type: (isInsert ? 'mutual.created' : isModify ? 'mutual.updated' : 'mutual.deleted') as ServerMessage['type'],
+              id: nanoid(),
+              payload: {
+                byEntityType: entityType,
+                byEntityId: entityId,
+                mutualEntityType: sk.split('#')[0],
+                entityId: sk.split('#')[1],
+                data: isRemove ? undefined : unmarshall(image as Record<string, any>),
+              },
+            }
+          : {
+              type: (isInsert ? 'entity.created' : isModify ? 'entity.updated' : 'entity.deleted') as ServerMessage['type'],
+              id: nanoid(),
+              payload: {
+                entityType,
+                entityId,
+                data: isRemove ? undefined : unmarshall(image as Record<string, any>),
+              },
+            },
+      );
     } catch (error) {
       console.error('Error broadcasting:', error);
     }
@@ -622,6 +654,7 @@ async function broadcastToSubscribers(
       TableName: tableName,
       KeyConditionExpression: 'PK = :pk',
       ExpressionAttributeValues: { ':pk': subKey },
+      ConsistentRead: true,
     }),
   );
 
@@ -660,6 +693,115 @@ async function broadcastToSubscribers(
             },
           }),
         );
+      }
+    }
+  }
+}
+
+/**
+ * Resolve feed subscribers affected by a change to entityType:entityId.
+ *
+ * For a mutual change in channel:A, we need to find all entities (e.g., users)
+ * that have a mutual relationship with channel:A, then check if they have
+ * a feed subscription that includes the changed entity type.
+ *
+ * For an entity change to channel:A, we check if any feed subscriber
+ * directly has channel:A as their feed entity.
+ */
+async function broadcastToFeedSubscribers(
+  managementApi: ApiGatewayManagementApiClient,
+  docClient: DynamoDBDocumentClient,
+  tableName: string,
+  byEntityType: string,
+  byEntityId: string,
+  changedEntityType: string,
+  message: ServerMessage,
+): Promise<void> {
+  // Step 1: Find all entities connected to byEntityType:byEntityId via mutuals
+  // Query the main table: PK = byEntityType#byEntityId, SK != META (mutual records)
+  const pk = `${byEntityType}#${byEntityId}`;
+  const mutualsResult = await docClient.send(
+    new QueryCommand({
+      TableName: tableName,
+      KeyConditionExpression: 'PK = :pk',
+      ExpressionAttributeValues: { ':pk': pk },
+      ConsistentRead: true,
+    }),
+  );
+
+  if (!mutualsResult.Items?.length) return;
+
+  // Collect unique connected entities (the "other side" of the mutual)
+  const connectedEntities = new Set<string>();
+
+  for (const item of mutualsResult.Items) {
+    const sk = item.SK as string;
+    if (!sk || sk === 'META' || sk.startsWith('#')) continue;
+
+    // SK format: entityType#entityId
+    const skParts = (sk as string).split('#');
+    if (skParts.length >= 2) {
+      const connEntityType = skParts[0];
+      const connEntityId = skParts[1];
+      connectedEntities.add(`${connEntityType}:${connEntityId}`);
+    }
+  }
+
+  // Also check the entity itself as a feed subscriber
+  connectedEntities.add(`${byEntityType}:${byEntityId}`);
+
+  // Step 2: For each connected entity, check if they have a feed subscription
+  const sentConnections = new Set<string>();
+
+  for (const connEntity of connectedEntities) {
+    const [entityType, entityId] = connEntity.split(':');
+    const feedSubKey = `${SUB_FEED}${entityType}:${entityId}`;
+
+    const feedSubsResult = await docClient.send(
+      new QueryCommand({
+        TableName: tableName,
+        KeyConditionExpression: 'PK = :pk',
+        ExpressionAttributeValues: { ':pk': feedSubKey },
+        ConsistentRead: true,
+      }),
+    );
+
+    if (!feedSubsResult.Items?.length) continue;
+
+    for (const feedSub of feedSubsResult.Items) {
+      const feedTypes = feedSub.feedTypes as string[] | undefined;
+      const connectionId = feedSub.connectionId as string;
+
+      // Check if the changed entity type is in the feed's allowed types
+      if (feedTypes && !feedTypes.includes(changedEntityType)) continue;
+
+      // Avoid sending duplicate messages to the same connection
+      if (sentConnections.has(connectionId)) continue;
+      sentConnections.add(connectionId);
+
+      try {
+        await managementApi.send(
+          new PostToConnectionCommand({
+            ConnectionId: connectionId,
+            Data: JSON.stringify(message),
+          }),
+        );
+      } catch (error: unknown) {
+        if (
+          error instanceof Error &&
+          (error.message?.includes('GoneException') ||
+            error.message?.includes('410'))
+        ) {
+          await docClient.send(
+            new DeleteCommand({
+              TableName: tableName,
+              Key: {
+                PK: feedSubKey,
+                SK: `${CONN_PREFIX}${connectionId}`,
+              },
+            }),
+          );
+        }
       }
     }
   }

--- a/packages/core/processors/websocket-processor.ts
+++ b/packages/core/processors/websocket-processor.ts
@@ -621,7 +621,7 @@ export const broadcast: DynamoDBStreamHandler = async (
         isMutual
           ? {
               type: (isInsert ? 'mutual.created' : isModify ? 'mutual.updated' : 'mutual.deleted') as ServerMessage['type'],
-              id: nanoid(),
+              id: ulid(),
               payload: {
                 byEntityType: entityType,
                 byEntityId: entityId,
@@ -632,7 +632,7 @@ export const broadcast: DynamoDBStreamHandler = async (
             }
           : {
               type: (isInsert ? 'entity.created' : isModify ? 'entity.updated' : 'entity.deleted') as ServerMessage['type'],
-              id: nanoid(),
+              id: ulid(),
               payload: {
                 entityType,
                 entityId,
@@ -741,7 +741,7 @@ async function broadcastToFeedSubscribers(
 
   for (const item of mutualsResult.Items) {
     const sk = item.SK as string;
-    if (!sk || sk === 'META' || sk.startsWith('#')) continue;
+    if (!sk || sk === '#METADATA#' || sk.startsWith('#')) continue;
 
     // SK format: entityType#entityId
     const skParts = (sk as string).split('#');
@@ -760,7 +760,7 @@ async function broadcastToFeedSubscribers(
 
   for (const connEntity of connectedEntities) {
     const [entityType, entityId] = connEntity.split(':');
-    const feedSubKey = `${SUB_FEED}${entityType}:${entityId}`;
+    const feedSubKey = `${SUB_FEED}${entityType}#${entityId}`;
 
     const feedSubsResult = await docClient.send(
       new QueryCommand({


### PR DESCRIPTION
## Summary

Phase 2 of the entity feed feature — the broadcast handler now resolves feed subscribers via the mutual graph.

- When a change occurs (e.g., new message in channel A), the broadcast handler traverses the mutual graph to find all entities connected to channel A (e.g., users in that channel)
- For each connected entity with a feed subscription, checks if the changed entity type is in their allowed `feedTypes`
- This is what makes the feed "graph-aware" — one subscription covers all related changes

## Changes

- `broadcastToFeedSubscribers()` function added to websocket processor
- Queries main table for mutual relationships of the changed entity
- Checks `SUB#FEED#` subscriptions for each connected entity
- Filters by `feedTypes` whitelist, deduplicates per-connection
- Cleans up stale feed subscriptions on `GoneException` (410)
- `ConsistentRead: true` on all broadcast subscriber queries (fixes intermittent one-directional message delivery)

## Depends on

- #215

## Test plan

- [ ] Create a feed subscription for user A connected to channel X
- [ ] Create a message in channel X
- [ ] Verify user A receives the `mutual.created` event via their feed
- [ ] Verify events for entity types NOT in feedTypes are filtered out
- [ ] Verify stale connections are cleaned up on GoneException