### PR TITLE
Websocket #4 - feat(react): add useEntityFeed hook

### DIFF
--- a/.changeset/entity-feed-hook.md
+++ b/.changeset/entity-feed-hook.md
@@ -1,0 +1,13 @@
+---
+"@monorise/react": minor
+---
+
+Add `useEntityFeed` hook for graph-aware real-time subscriptions.
+
+- Ticket-based WebSocket connection (default route or custom ticketEndpoint)
+- Auto-routes entity/mutual broadcast events into zustand stores
+- Proactive ticket refresh before expiry
+- Periodic sleep detection with automatic reconnect
+- Ticket fetch retry with exponential backoff on transient errors
+- Stale manager identity check prevents reconnect loops
+- React strict mode safe via connectingRef guard

--- a/packages/react/actions/websocket.action.ts
+++ b/packages/react/actions/websocket.action.ts
@@ -494,6 +494,8 @@ export const initWebSocketActions = (
     const wsManagerRef = useRef<WebSocketManager | null>(null);
     const isMountedRef = useRef(true);
     const connectingRef = useRef(false);
+    const reconnectCountRef = useRef(0);
+    const lastConnectedAtRef = useRef(0);
 
     const fetchTicket = useCallback(async () => {
       try {
@@ -585,11 +587,26 @@ export const initWebSocketActions = (
 
         if (state === 'connected') {
           connectingRef.current = false;
+          reconnectCountRef.current = 0;
+          lastConnectedAtRef.current = Date.now();
           setIsConnected(true);
           setError(null);
         } else if (state === 'disconnected') {
           connectingRef.current = false;
           setIsConnected(false);
+
+          // Only auto-reconnect if we were connected for >5s (stable connection)
+          // and haven't exceeded max reconnect attempts
+          const wasStable = Date.now() - lastConnectedAtRef.current > 5000;
+          if (wasStable && reconnectCountRef.current < 5) {
+            reconnectCountRef.current++;
+            const delay = 2000 * Math.pow(2, reconnectCountRef.current - 1);
+            setTimeout(() => {
+              if (isMountedRef.current && !connectingRef.current) {
+                connectRef.current();
+              }
+            }, delay);
+          }
         }
       });
 
@@ -681,25 +698,35 @@ export const initWebSocketActions = (
       }
 
       // Detect wake from sleep using periodic check
-      // visibilitychange doesn't reliably fire on laptop sleep
       let lastCheckTime = Date.now();
       const sleepCheckInterval = setInterval(() => {
         const now = Date.now();
         const elapsed = now - lastCheckTime;
         lastCheckTime = now;
 
-        // If >30s elapsed since last check, device was likely asleep
         if (elapsed > 30000 && wsManagerRef.current) {
           wsManagerRef.current.disconnect();
           wsManagerRef.current = null;
           connectingRef.current = false;
+          reconnectCountRef.current = 0;
           connectRef.current();
         }
       }, 5000);
 
+      // Reconnect when network comes back online
+      const handleOnline = () => {
+        if (!isMountedRef.current) return;
+        if (wsManagerRef.current?.getState() === 'connected') return;
+        if (connectingRef.current) return;
+        reconnectCountRef.current = 0;
+        connectRef.current();
+      };
+      window.addEventListener('online', handleOnline);
+
       return () => {
         isMountedRef.current = false;
         clearInterval(sleepCheckInterval);
+        window.removeEventListener('online', handleOnline);
         if (refreshTimerRef.current) {
           clearTimeout(refreshTimerRef.current);
         }

--- a/packages/react/actions/websocket.action.ts
+++ b/packages/react/actions/websocket.action.ts
@@ -95,6 +95,7 @@ export const initWebSocketActions = (
     });
 
     const fetchData = async (type: 'initial' | 'more' | 'refresh') => {
+      if (!httpActions) return;
       if (type === 'more') {
         setIsFetchingMore(true);
       } else if (type === 'refresh') {
@@ -106,7 +107,7 @@ export const initWebSocketActions = (
 
       try {
         const fetchLastKey = type === 'refresh' ? undefined : lastKeyRef.current;
-        const result = await httpActions!.listEntities(entityType, {
+        const result = await httpActions.listEntities(entityType, {
           limit,
           lastKey: fetchLastKey,
         });
@@ -254,7 +255,7 @@ export const initWebSocketActions = (
     });
 
     const fetchData = async (type: 'initial' | 'more' | 'refresh') => {
-      if (!byEntityId) return;
+      if (!byEntityId || !httpActions) return;
 
       if (type === 'more') {
         setIsFetchingMore(true);
@@ -267,7 +268,7 @@ export const initWebSocketActions = (
 
       try {
         const fetchLastKey = type === 'refresh' ? undefined : lastKeyRef.current;
-        const result = await httpActions!.listEntitiesByEntity(
+        const result = await httpActions.listEntitiesByEntity(
           byEntityType,
           byEntityId,
           mutualEntityType,
@@ -495,6 +496,7 @@ export const initWebSocketActions = (
     const isMountedRef = useRef(true);
     const connectingRef = useRef(false);
     const reconnectCountRef = useRef(0);
+    const connectRef = useRef<() => void>(() => {});
     const lastConnectedAtRef = useRef(0);
 
     const fetchTicket = useCallback(async () => {
@@ -687,7 +689,6 @@ export const initWebSocketActions = (
       }, refreshMs);
     }, [fetchTicket]);
 
-    const connectRef = useRef(connectWithTicket);
     connectRef.current = connectWithTicket;
 
     useEffect(() => {

--- a/packages/react/actions/websocket.action.ts
+++ b/packages/react/actions/websocket.action.ts
@@ -30,6 +30,17 @@ export interface UseMutualSocketReturn<T extends Entity> {
   hasMore: boolean;
 }
 
+export interface UseEntityFeedOptions {
+  entityType: Entity;
+  entityId: string;
+  ticketEndpoint?: string;
+}
+
+export interface UseEntityFeedReturn {
+  isConnected: boolean;
+  error: { code: string; message: string } | null;
+}
+
 let globalWsManager: WebSocketManager | null = null;
 let wsEndpoint: string | undefined;
 
@@ -51,7 +62,7 @@ export const getWebSocketManager = () => globalWsManager;
 
 export const initWebSocketActions = (
   monoriseStore: MonoriseStore,
-  httpActions: {
+  httpActions?: {
     listEntities: <T extends Entity>(
       entityType: T,
       params?: { limit?: number; lastKey?: string },
@@ -95,7 +106,7 @@ export const initWebSocketActions = (
 
       try {
         const fetchLastKey = type === 'refresh' ? undefined : lastKeyRef.current;
-        const result = await httpActions.listEntities(entityType, {
+        const result = await httpActions!.listEntities(entityType, {
           limit,
           lastKey: fetchLastKey,
         });
@@ -256,7 +267,7 @@ export const initWebSocketActions = (
 
       try {
         const fetchLastKey = type === 'refresh' ? undefined : lastKeyRef.current;
-        const result = await httpActions.listEntitiesByEntity(
+        const result = await httpActions!.listEntitiesByEntity(
           byEntityType,
           byEntityId,
           mutualEntityType,
@@ -459,10 +470,206 @@ export const initWebSocketActions = (
     return { isSubscribed, send };
   };
 
+  /**
+   * Subscribe to an entity's real-time feed.
+   *
+   * Fetches a ticket (via ticketEndpoint or default monorise route through catch-all proxy),
+   * establishes a WebSocket connection, and auto-updates entity/mutual stores.
+   * Handles ticket refresh and auto-resync on reconnect.
+   *
+   * @example
+   * ```tsx
+   * // Internal app (uses catch-all proxy)
+   * useEntityFeed({ entityType: Entity.USER, entityId: userId });
+   *
+   * // Client-facing app (custom auth endpoint)
+   * useEntityFeed({ entityType: Entity.USER, entityId: userId, ticketEndpoint: '/api/ws/ticket' });
+   * ```
+   */
+  const useEntityFeed = (opts: UseEntityFeedOptions): UseEntityFeedReturn => {
+    const { entityType, entityId, ticketEndpoint } = opts;
+    const [isConnected, setIsConnected] = useState(false);
+    const [error, setError] = useState<{ code: string; message: string } | null>(null);
+    const refreshTimerRef = useRef<NodeJS.Timeout | null>(null);
+    const wsManagerRef = useRef<WebSocketManager | null>(null);
+    const isMountedRef = useRef(true);
+
+    const fetchTicket = useCallback(async () => {
+      try {
+        const url = ticketEndpoint
+          || `/api/core/ws/ticket/${entityType}/${entityId}`;
+
+        const fetchOpts: RequestInit = {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        };
+
+        // Only send body for custom endpoints (default route gets params from URL)
+        if (ticketEndpoint) {
+          fetchOpts.body = JSON.stringify({ entityType, entityId });
+        }
+
+        const response = await fetch(url, fetchOpts);
+
+        if (response.status === 401 || response.status === 403) {
+          return { error: { code: 'TICKET_UNAUTHORIZED', message: 'Unauthorized' } };
+        }
+
+        if (!response.ok) {
+          return { error: { code: 'TICKET_FAILED', message: `HTTP ${response.status}` } };
+        }
+
+        const data = await response.json();
+        return { data: data as { ticket: string; wsUrl: string; expiresIn: number } };
+      } catch (err) {
+        return { error: { code: 'TICKET_FAILED', message: (err as Error).message } };
+      }
+    }, [entityType, entityId, ticketEndpoint]);
+
+    const connectWithTicket = useCallback(async () => {
+      const result = await fetchTicket();
+
+      if (!isMountedRef.current) return;
+
+      if (result.error) {
+        setError(result.error);
+        setIsConnected(false);
+        return;
+      }
+
+      setError(null);
+      const { ticket, wsUrl, expiresIn } = result.data!;
+
+      // Disconnect existing connection if any
+      if (wsManagerRef.current) {
+        wsManagerRef.current.disconnect();
+      }
+
+      // Use the WebSocketManager class from the module scope
+      // Import dynamically to avoid circular deps
+      const { WebSocketManager: WsManagerClass } = await import('../websocket');
+
+      const manager = new WsManagerClass(wsUrl, ticket);
+      wsManagerRef.current = manager;
+
+      // Also set as global so other hooks (useMutualSocket etc.) can use it
+      globalWsManager = manager;
+
+      manager.onStateChange((state: ConnectionState) => {
+        if (!isMountedRef.current) return;
+
+        if (state === 'connected') {
+          setIsConnected(true);
+          setError(null);
+        } else if (state === 'disconnected') {
+          setIsConnected(false);
+        }
+      });
+
+      // Route feed messages into stores
+      manager.onMessage((msg: ServerMessage) => {
+        if (!isMountedRef.current) return;
+
+        if (msg.type === 'entity.created' || msg.type === 'entity.updated') {
+          const payload = msg.payload as {
+            entityType: string;
+            entityId: string;
+            data?: any;
+          };
+          if (payload.data) {
+            monoriseStore.setState(
+              produce((state) => {
+                const key = payload.entityType;
+                if (!state.entity[key]) {
+                  state.entity[key] = { dataMap: new Map(), isFirstFetched: false, lastKey: undefined };
+                }
+                state.entity[key].dataMap.set(payload.entityId, payload.data);
+              }),
+            );
+          }
+        } else if (msg.type === 'entity.deleted') {
+          const payload = msg.payload as { entityType: string; entityId: string };
+          monoriseStore.setState(
+            produce((state) => {
+              state.entity[payload.entityType]?.dataMap?.delete(payload.entityId);
+            }),
+          );
+        } else if (msg.type === 'mutual.created' || msg.type === 'mutual.updated') {
+          const payload = msg.payload as {
+            byEntityType: string;
+            byEntityId: string;
+            mutualEntityType: string;
+            entityId: string;
+            data?: any;
+          };
+          if (payload.data) {
+            const mutualKey = `${payload.byEntityType}/${payload.byEntityId}/${payload.mutualEntityType}`;
+            monoriseStore.setState(
+              produce((state) => {
+                if (!state.mutual[mutualKey]) {
+                  state.mutual[mutualKey] = { dataMap: new Map(), isFirstFetched: false, lastKey: undefined };
+                }
+                state.mutual[mutualKey].dataMap.set(payload.entityId, payload.data);
+              }),
+            );
+          }
+        } else if (msg.type === 'mutual.deleted') {
+          const payload = msg.payload as {
+            byEntityType: string;
+            byEntityId: string;
+            mutualEntityType: string;
+            entityId: string;
+          };
+          const mutualKey = `${payload.byEntityType}/${payload.byEntityId}/${payload.mutualEntityType}`;
+          monoriseStore.setState(
+            produce((state) => {
+              state.mutual[mutualKey]?.dataMap?.delete(payload.entityId);
+            }),
+          );
+        }
+      });
+
+      manager.connect();
+
+      // Schedule proactive ticket refresh
+      if (refreshTimerRef.current) {
+        clearTimeout(refreshTimerRef.current);
+      }
+      const refreshMs = Math.max((expiresIn - 120) * 1000, 60000); // refresh 2 min before expiry, minimum 1 min
+      refreshTimerRef.current = setTimeout(() => {
+        if (isMountedRef.current) {
+          connectWithTicket();
+        }
+      }, refreshMs);
+    }, [fetchTicket]);
+
+    useEffect(() => {
+      isMountedRef.current = true;
+
+      if (entityId) {
+        connectWithTicket();
+      }
+
+      return () => {
+        isMountedRef.current = false;
+        if (refreshTimerRef.current) {
+          clearTimeout(refreshTimerRef.current);
+        }
+        if (wsManagerRef.current) {
+          wsManagerRef.current.disconnect();
+          wsManagerRef.current = null;
+        }
+      };
+    }, [entityType, entityId, connectWithTicket]);
+
+    return { isConnected, error };
+  };
+
   return {
     useEntitySocket,
     useMutualSocket,
     useEphemeralSocket,
+    useEntityFeed,
   };
 };
 

--- a/packages/react/actions/websocket.action.ts
+++ b/packages/react/actions/websocket.action.ts
@@ -493,6 +493,7 @@ export const initWebSocketActions = (
     const refreshTimerRef = useRef<NodeJS.Timeout | null>(null);
     const wsManagerRef = useRef<WebSocketManager | null>(null);
     const isMountedRef = useRef(true);
+    const connectingRef = useRef(false);
 
     const fetchTicket = useCallback(async () => {
       try {
@@ -527,41 +528,67 @@ export const initWebSocketActions = (
     }, [entityType, entityId, ticketEndpoint]);
 
     const connectWithTicket = useCallback(async () => {
-      const result = await fetchTicket();
+      if (connectingRef.current) return;
+      connectingRef.current = true;
 
-      if (!isMountedRef.current) return;
+      // Retry ticket fetch with backoff
+      let result: Awaited<ReturnType<typeof fetchTicket>> | null = null;
+      const maxRetries = 3;
+      for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        result = await fetchTicket();
 
-      if (result.error) {
-        setError(result.error);
+        if (!isMountedRef.current) {
+          connectingRef.current = false;
+          return;
+        }
+
+        if (!result.error) break;
+
+        // Don't retry auth errors
+        if (result.error.code === 'TICKET_UNAUTHORIZED') break;
+
+        if (attempt < maxRetries) {
+          await new Promise((r) => setTimeout(r, 1000 * Math.pow(2, attempt)));
+          if (!isMountedRef.current) {
+            connectingRef.current = false;
+            return;
+          }
+        }
+      }
+
+      if (result!.error) {
+        setError(result!.error);
         setIsConnected(false);
+        connectingRef.current = false;
         return;
       }
 
       setError(null);
-      const { ticket, wsUrl, expiresIn } = result.data!;
-
-      // Disconnect existing connection if any
+      const { ticket, wsUrl, expiresIn } = result!.data!;
+      // Disconnect existing connection
       if (wsManagerRef.current) {
         wsManagerRef.current.disconnect();
       }
 
-      // Use the WebSocketManager class from the module scope
-      // Import dynamically to avoid circular deps
       const { WebSocketManager: WsManagerClass } = await import('../websocket');
 
-      const manager = new WsManagerClass(wsUrl, ticket);
+      const wsUrlWithTicket = `${wsUrl}?ticket=${encodeURIComponent(ticket)}`;
+      const manager = new WsManagerClass(wsUrlWithTicket, '');
+      manager.disableAutoReconnect = true;
       wsManagerRef.current = manager;
-
-      // Also set as global so other hooks (useMutualSocket etc.) can use it
       globalWsManager = manager;
 
       manager.onStateChange((state: ConnectionState) => {
         if (!isMountedRef.current) return;
+        // Ignore events from old managers (stale callbacks)
+        if (wsManagerRef.current !== manager) return;
 
         if (state === 'connected') {
+          connectingRef.current = false;
           setIsConnected(true);
           setError(null);
         } else if (state === 'disconnected') {
+          connectingRef.current = false;
           setIsConnected(false);
         }
       });
@@ -638,20 +665,41 @@ export const initWebSocketActions = (
       const refreshMs = Math.max((expiresIn - 120) * 1000, 60000); // refresh 2 min before expiry, minimum 1 min
       refreshTimerRef.current = setTimeout(() => {
         if (isMountedRef.current) {
-          connectWithTicket();
+          connectRef.current();
         }
       }, refreshMs);
     }, [fetchTicket]);
+
+    const connectRef = useRef(connectWithTicket);
+    connectRef.current = connectWithTicket;
 
     useEffect(() => {
       isMountedRef.current = true;
 
       if (entityId) {
-        connectWithTicket();
+        connectRef.current();
       }
+
+      // Detect wake from sleep using periodic check
+      // visibilitychange doesn't reliably fire on laptop sleep
+      let lastCheckTime = Date.now();
+      const sleepCheckInterval = setInterval(() => {
+        const now = Date.now();
+        const elapsed = now - lastCheckTime;
+        lastCheckTime = now;
+
+        // If >30s elapsed since last check, device was likely asleep
+        if (elapsed > 30000 && wsManagerRef.current) {
+          wsManagerRef.current.disconnect();
+          wsManagerRef.current = null;
+          connectingRef.current = false;
+          connectRef.current();
+        }
+      }, 5000);
 
       return () => {
         isMountedRef.current = false;
+        clearInterval(sleepCheckInterval);
         if (refreshTimerRef.current) {
           clearTimeout(refreshTimerRef.current);
         }
@@ -660,7 +708,7 @@ export const initWebSocketActions = (
           wsManagerRef.current = null;
         }
       };
-    }, [entityType, entityId, connectWithTicket]);
+    }, [entityType, entityId]);
 
     return { isConnected, error };
   };

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -6,7 +6,7 @@ import { initConfigActions } from './actions/config.action';
 import { initCoreActions } from './actions/core.action';
 import {
   initWebSocketActions,
-  initWebSocket,
+  initializeWebSocketManager,
   getWebSocketManager,
 } from './actions/websocket.action';
 import {
@@ -160,10 +160,10 @@ const {
   getEntity,
   updateLocalTaggedEntity,
   deleteLocalTaggedEntity,
-  useWebSocketConnection,
   useEntitySocket,
   useMutualSocket,
   useEphemeralSocket,
+  useEntityFeed,
 } = Monorise;
 
 export {
@@ -219,11 +219,11 @@ export {
   getEntity,
   updateLocalTaggedEntity,
   deleteLocalTaggedEntity,
-  useWebSocketConnection,
   useEntitySocket,
   useMutualSocket,
   useEphemeralSocket,
-  initWebSocket,
+  useEntityFeed,
+  initializeWebSocketManager,
   getWebSocketManager,
   WebSocketManager,
   type ConnectionState,

--- a/packages/react/websocket/WebSocketManager.ts
+++ b/packages/react/websocket/WebSocketManager.ts
@@ -383,20 +383,7 @@ export class WebSocketManager {
   }
 
   private startHeartbeat(): void {
-    let lastHeartbeatTime = Date.now();
-
     this.heartbeatInterval = setInterval(() => {
-      const now = Date.now();
-      const elapsed = now - lastHeartbeatTime;
-      lastHeartbeatTime = now;
-
-      // If significantly more time passed than the interval, device was asleep
-      if (elapsed > this.heartbeatIntervalMs * 2) {
-        console.warn('WebSocket: detected wake from sleep, closing stale connection');
-        this.ws?.close();
-        return;
-      }
-
       const pingMessage: ClientMessage = {
         action: 'ping',
         id: nanoid(),
@@ -405,7 +392,6 @@ export class WebSocketManager {
       this.send(pingMessage);
 
       this.heartbeatTimeout = setTimeout(() => {
-        console.warn('WebSocket heartbeat timeout - closing connection');
         this.ws?.close();
       }, this.heartbeatTimeoutMs);
     }, this.heartbeatIntervalMs);

--- a/packages/react/websocket/WebSocketManager.ts
+++ b/packages/react/websocket/WebSocketManager.ts
@@ -80,6 +80,8 @@ export class WebSocketManager {
   private ephemeralSubscriptions: Map<string, EphemeralSubscription> = new Map();
   private pendingMessages: ClientMessage[] = [];
 
+  public disableAutoReconnect = false;
+
   constructor(url: string, token: string) {
     this.url = url;
     this.token = token;
@@ -91,8 +93,10 @@ export class WebSocketManager {
     this.setState('connecting');
 
     try {
-      const urlWithToken = `${this.url}?token=${encodeURIComponent(this.token)}`;
-      this.ws = new WebSocket(urlWithToken);
+      const connectUrl = this.token
+        ? `${this.url}?token=${encodeURIComponent(this.token)}`
+        : this.url;
+      this.ws = new WebSocket(connectUrl);
 
       this.ws.onopen = this.handleOpen.bind(this);
       this.ws.onclose = this.handleClose.bind(this);
@@ -290,6 +294,11 @@ export class WebSocketManager {
     this.stopHeartbeat();
     this.ws = null;
 
+    if (this.disableAutoReconnect) {
+      this.setState('disconnected');
+      return;
+    }
+
     if (this.reconnectAttempts < this.maxReconnectAttempts) {
       this.setState('reconnecting');
       this.scheduleReconnect();
@@ -374,7 +383,20 @@ export class WebSocketManager {
   }
 
   private startHeartbeat(): void {
+    let lastHeartbeatTime = Date.now();
+
     this.heartbeatInterval = setInterval(() => {
+      const now = Date.now();
+      const elapsed = now - lastHeartbeatTime;
+      lastHeartbeatTime = now;
+
+      // If significantly more time passed than the interval, device was asleep
+      if (elapsed > this.heartbeatIntervalMs * 2) {
+        console.warn('WebSocket: detected wake from sleep, closing stale connection');
+        this.ws?.close();
+        return;
+      }
+
       const pingMessage: ClientMessage = {
         action: 'ping',
         id: nanoid(),
@@ -383,7 +405,7 @@ export class WebSocketManager {
       this.send(pingMessage);
 
       this.heartbeatTimeout = setTimeout(() => {
-        console.warn('WebSocket heartbeat timeout - reconnecting');
+        console.warn('WebSocket heartbeat timeout - closing connection');
         this.ws?.close();
       }, this.heartbeatTimeoutMs);
     }, this.heartbeatIntervalMs);


### PR DESCRIPTION
## Summary

Phase 3 of the entity feed feature — the React hook that manages ticket lifecycle, WebSocket connection, and store updates.

## Changes

- `useEntityFeed({ entityType, entityId, ticketEndpoint? })` hook
- Default ticket endpoint: `POST /api/core/ws/ticket/:entityType/:entityId` (catch-all proxy)
- Custom endpoint: developer's own proxy route with their auth
- Routes `entity.created/updated/deleted` and `mutual.created/updated/deleted` into zustand stores
- Proactive ticket refresh (2 min before expiry) with reactive fallback
- Sets `globalWsManager` so `useMutualSocket`, `useEphemeralSocket` etc. coexist
- `UseEntityFeedOptions` and `UseEntityFeedReturn` exported interfaces
- `httpActions` parameter made optional in `initWebSocketActions`

### Reconnect handling

- **Stable disconnect** (connected >5s then dropped): auto-reconnect with exponential backoff (2s→4s→8s→16s→32s), max 5 attempts
- **Unstable disconnect** (connected <5s): no reconnect — prevents infinite loop
- **Network recovery**: browser `online` event triggers immediate reconnect (skips if already connected/connecting)
- **Sleep/wake**: periodic interval (5s) detects >30s elapsed time, force-reconnects with fresh ticket
- **Stale manager**: identity check (`wsManagerRef.current !== manager`) ignores events from old managers
- **Concurrent guard**: `connectingRef` prevents double-connect from rapid events or React strict mode
- **Ticket retry**: 3 attempts with 1s→2s→4s backoff on transient errors, auth errors fail immediately

## Depends on

- #216

## Test plan

- [ ] Verify `useEntityFeed` fetches ticket and connects via WebSocket
- [ ] Verify entity store updates when entity broadcast arrives
- [ ] Verify mutual store updates when mutual broadcast arrives
- [ ] Verify ticket refreshes before expiry
- [ ] Turn off wifi → verify reconnect attempts with backoff → turn on wifi → verify recovers to "Live"
- [ ] Sleep laptop >30s → wake → verify reconnects
- [ ] Verify `TICKET_UNAUTHORIZED` error surfaces when proxy returns 401
- [ ] Verify no reconnect loop when connection drops immediately