### PR TITLE
Websocket #7 - docs: add WebSocket documentation

### DIFF
--- a/www/docs/.vitepress/config.ts
+++ b/www/docs/.vitepress/config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       { text: 'Guide', link: '/getting-started' },
       { text: 'Concepts', link: '/concepts/' },
       { text: 'React SDK', link: '/react' },
+      { text: 'WebSocket', link: '/websocket' },
       { text: 'Roadmap', link: '/roadmap' },
     ],
 
@@ -59,6 +60,7 @@ export default defineConfig({
         items: [
           { text: 'Package Map', link: '/packages' },
           { text: 'React SDK', link: '/react' },
+          { text: 'WebSocket', link: '/websocket' },
           { text: 'SST SDK', link: '/sst' },
         ],
       },

--- a/www/docs/packages.md
+++ b/www/docs/packages.md
@@ -15,6 +15,7 @@ import { createEntityConfig } from 'monorise/base';
 import { useEntities, useMutuals } from 'monorise/react';
 import { CoreFactory } from 'monorise/core';
 import { MonoriseCore } from 'monorise/sst';
+import { generateWebSocketTicket } from 'monorise/proxy';
 ```
 
 ## Individual packages
@@ -26,6 +27,7 @@ import { MonoriseCore } from 'monorise/sst';
 | `@monorise/cli` | Generates `.monorise/config.ts` + `.monorise/handle.ts` | `npm i @monorise/cli` |
 | `@monorise/react` | Client SDK — hooks, stores, axios helpers | `npm i @monorise/react` |
 | `@monorise/sst` | SST v3 module — API, bus, table, queues, processors | `npm i @monorise/sst` |
+| `@monorise/proxy` | Server-side helpers for proxy routes (ticket generation) | `npm i @monorise/proxy` |
 
 ## `monorise/base`
 
@@ -49,9 +51,17 @@ The code generation tool. Watches your entity config files and generates:
 
 The frontend SDK for React applications. Provides:
 - **Hooks**: `useEntities`, `useEntity`, `useMutuals`, `useTaggedEntities`
+- **WebSocket hooks**: `useEntityFeed`, `useEntitySocket`, `useMutualSocket`, `useEphemeralSocket`
 - **Actions**: `createEntity`, `editEntity`, `deleteEntity`, `createMutual`
 - **State management**: Zustand-based stores with optimistic updates
 - **Utilities**: Modal management, loading/error stores
+
+## `monorise/proxy`
+
+Server-side helpers for proxy routes. Currently provides:
+- **`generateWebSocketTicket()`** — issues a WebSocket ticket for entity feed subscriptions. Call this from your proxy route after validating auth.
+
+See [WebSocket > Entity Feed](/websocket#entity-feed) for usage.
 
 ## `monorise/sst`
 
@@ -71,3 +81,4 @@ The SST v3 infrastructure module. Creates:
 | CLI generator | `packages/cli/*` |
 | Shared types | `packages/base/*` |
 | React SDK | `packages/react/*` |
+| Proxy helpers | `packages/proxy/*` |

--- a/www/docs/react.md
+++ b/www/docs/react.md
@@ -303,5 +303,3 @@ Monorise provides WebSocket hooks for real-time updates. These are documented in
 
 The feed hook auto-updates the same stores that `useEntities` and `useMutuals` read from — no new API to learn. See the [WebSocket chat example](/websocket#example-chat-app) for a complete working app with entity feed, unread tracking, typing indicators, and connection recovery.
 
-The feed hook auto-updates the same stores that `useEntities` and `useMutuals` read from — no new API to learn.
-

--- a/www/docs/react.md
+++ b/www/docs/react.md
@@ -301,5 +301,7 @@ Monorise provides WebSocket hooks for real-time updates. These are documented in
 | `useMutualSocket(byType, byId, entityType, opts?)` | Subscribe to mutual changes for a specific entity pair |
 | `useEphemeralSocket(channel, opts?)` | Non-persisted messages (typing indicators, presence) |
 
+The feed hook auto-updates the same stores that `useEntities` and `useMutuals` read from — no new API to learn. See the [WebSocket chat example](/websocket#example-chat-app) for a complete working app with entity feed, unread tracking, typing indicators, and connection recovery.
+
 The feed hook auto-updates the same stores that `useEntities` and `useMutuals` read from — no new API to learn.
 

--- a/www/docs/react.md
+++ b/www/docs/react.md
@@ -288,3 +288,18 @@ When you call `createEntity`, `editEntity`, or `deleteEntity`, the store automat
 
 This means `useMutuals` and `useTaggedEntities` reflect changes immediately without a manual refetch.
 
+---
+
+## WebSocket Hooks
+
+Monorise provides WebSocket hooks for real-time updates. These are documented in detail on the [WebSocket](/websocket) page.
+
+| Hook | Purpose |
+|------|---------|
+| `useEntityFeed(opts)` | Graph-aware real-time feed for an entity — recommended for most apps |
+| `useEntitySocket(entityType, opts?)` | Subscribe to all CRUD events for an entity type |
+| `useMutualSocket(byType, byId, entityType, opts?)` | Subscribe to mutual changes for a specific entity pair |
+| `useEphemeralSocket(channel, opts?)` | Non-persisted messages (typing indicators, presence) |
+
+The feed hook auto-updates the same stores that `useEntities` and `useMutuals` read from — no new API to learn.
+

--- a/www/docs/sst.md
+++ b/www/docs/sst.md
@@ -46,7 +46,7 @@ new MonoriseCore(id: string, args?: MonoriseCoreArgs)
 | `tableTtl` | `string` | — | DynamoDB TTL attribute name |
 | `slackWebhook` | `string` | — | Slack webhook URL for DLQ alerts |
 | `configRoot` | `string` | — | Custom root path for monorise config |
-| `webSocket` | `{ enabled: true, handler?: { memory?, timeout? } }` | — | Enable WebSocket support for real-time updates. See [WebSocket](/websocket) |
+| `webSocket` | `{ enabled: true, handler?: { memory?, timeout? } }` | Disabled | Enable WebSocket support for real-time updates. See [WebSocket](/websocket) |
 
 ### Exposed resources
 

--- a/www/docs/sst.md
+++ b/www/docs/sst.md
@@ -46,6 +46,7 @@ new MonoriseCore(id: string, args?: MonoriseCoreArgs)
 | `tableTtl` | `string` | — | DynamoDB TTL attribute name |
 | `slackWebhook` | `string` | — | Slack webhook URL for DLQ alerts |
 | `configRoot` | `string` | — | Custom root path for monorise config |
+| `webSocket` | `{ enabled: true, handler?: { memory?, timeout? } }` | — | Enable WebSocket support for real-time updates. See [WebSocket](/websocket) |
 
 ### Exposed resources
 
@@ -73,6 +74,7 @@ bus.subscribe('custom-handler', {
 | `table` | `SingleTable` | DynamoDB single table with GSIs and replication |
 | `table.table` | `sst.aws.Dynamo` | The underlying DynamoDB table resource |
 | `alarmTopic` | `sst.aws.SnsTopic` | SNS topic for DLQ alarms — connected to Slack webhook notifications when `slackWebhook` is configured. Reuse this when creating custom `QFunction` processors to get alerts in the same Slack channel |
+| `websocket` | `sst.aws.ApiGatewayWebSocket \| undefined` | WebSocket API Gateway — only present when `webSocket.enabled` is set. Provides `.url` (client connection URL) and `.managementEndpoint` (server-side push URL) |
 
 ### What it provisions
 

--- a/www/docs/websocket.md
+++ b/www/docs/websocket.md
@@ -251,3 +251,74 @@ useEntityFeed()
   ◄── { type: 'entity.created', payload: ... }
        (auto-updates zustand store)
 ```
+
+## Example: Chat App
+
+A full working chat application demonstrates the WebSocket features end-to-end.
+
+**[Live demo](https://d1n9mvjkvdjtz1.cloudfront.net/)** · **[Source code](https://github.com/monorist/monorise/tree/main/examples/websocket-chat)**
+
+### What it demonstrates
+
+- **Entity feed** — `useEntityFeed` provides real-time updates across all joined channels with a single hook
+- **Channel membership** — users join channels via mutuals; sidebar separates "Joined" and "Browse" sections
+- **Unread messages** — `lastReadAt` stored as mutual data between user and channel, unread count badge in the sidebar, "New" divider in the conversation view
+- **Typing indicators** — `useEphemeralSocket` for non-persisted real-time events
+- **Connection recovery** — automatic reconnect after network drops and sleep/wake
+
+### Key patterns
+
+#### Setting up the feed
+
+```tsx
+function ChatApp({ currentUserId }) {
+  const { isConnected, error } = useEntityFeed({
+    entityType: Entity.USER,
+    entityId: currentUserId,
+  });
+
+  // Existing hooks automatically reflect real-time changes
+  const { mutuals: joinedChannels } = useMutuals(
+    Entity.USER, Entity.CHANNEL, currentUserId,
+  );
+}
+```
+
+#### Tracking unread messages
+
+Store a `lastReadAt` timestamp as mutual data between user and channel. When the user views a channel, update it:
+
+```tsx
+// Mark channel as read
+editMutual(Entity.USER, Entity.CHANNEL, userId, channelId, {
+  lastReadAt: new Date().toISOString(),
+});
+```
+
+Count unread messages by listening for incoming feed messages on non-active channels:
+
+```tsx
+const ws = getWebSocketManager();
+ws.onMessage((msg) => {
+  if (msg.type !== 'mutual.created') return;
+  const { byEntityType, mutualEntityType, byEntityId } = msg.payload;
+  if (byEntityType !== 'channel' || mutualEntityType !== 'message') return;
+  if (byEntityId === selectedChannelId) return; // skip active channel
+  // increment unread count for byEntityId
+});
+```
+
+#### Typing indicators
+
+```tsx
+// Send
+const { send } = useEphemeralSocket(`channel:${channelId}:typing`);
+send({ type: 'typing', userId, userName });
+
+// Receive
+useEphemeralSocket(`channel:${channelId}:typing`, {
+  onMessage: (data) => {
+    // show typing indicator for data.userName
+  },
+});
+```

--- a/www/docs/websocket.md
+++ b/www/docs/websocket.md
@@ -1,0 +1,253 @@
+# WebSocket
+
+Monorise includes optional WebSocket support for real-time entity and mutual updates. It follows the same philosophy as the rest of monorise: HTTP for mutations (reliable), WebSocket for live updates (efficient).
+
+::: warning
+WebSocket is an optional feature. Your app works fine without it — `useEntities` and `useMutuals` fetch via HTTP. WebSocket adds real-time push on top of that.
+:::
+
+## Enabling WebSocket
+
+Add `webSocket: { enabled: true }` to your MonoriseCore config:
+
+```ts
+// sst.config.ts
+const core = new monorise.module.Core('app', {
+  webSocket: { enabled: true },
+  allowOrigins: ['http://localhost:3000'],
+});
+```
+
+This provisions:
+- An API Gateway WebSocket API (`$connect`, `$disconnect`, `$default` routes)
+- A broadcast Lambda that subscribes to DynamoDB Streams and pushes changes to connected clients
+- Connection and subscription records in the existing single table
+
+## Subscription Types
+
+Monorise supports four subscription types, from low-level to high-level:
+
+| Type | Hook | Purpose |
+|------|------|---------|
+| Entity | `useEntitySocket` | All CRUD events for an entity type |
+| Mutual | `useMutualSocket` | Mutual changes for a specific entity pair |
+| Ephemeral | `useEphemeralSocket` | Non-persisted messages (typing indicators, presence) |
+| Feed | `useEntityFeed` | Graph-aware: all changes relevant to an entity |
+
+### Entity socket
+
+Subscribe to all changes of an entity type. Returns an array, consistent with `useEntities`.
+
+```ts
+const { entities, isLoading, isSubscribed, fetchMore, hasMore } =
+  useEntitySocket(Entity.CHANNEL);
+```
+
+When a channel is created, updated, or deleted anywhere, all subscribers receive the update and the local store is updated automatically.
+
+### Mutual socket
+
+Subscribe to mutual changes for a specific entity pair. Returns an array, consistent with `useMutuals`.
+
+```ts
+const { mutuals, isLoading, isSubscribed, fetchMore, hasMore } =
+  useMutualSocket(Entity.CHANNEL, channelId, Entity.MESSAGE, { limit: 50 });
+```
+
+Fetches messages via HTTP on mount, then receives real-time updates via WebSocket. Auto-refetches on reconnect to fill any gaps.
+
+### Ephemeral socket
+
+Send and receive non-persisted messages on a named channel. Nothing is stored in DynamoDB.
+
+```ts
+// Receive
+useEphemeralSocket<{ userId: string; type: 'typing' | 'stopped' }>(
+  `channel:${channelId}:typing`,
+  {
+    onMessage: (data, senderId) => {
+      // Handle typing indicator
+    },
+  },
+);
+
+// Send
+const { send } = useEphemeralSocket<{ userId: string; type: 'typing' }>(
+  `channel:${channelId}:typing`,
+);
+send({ userId: currentUserId, type: 'typing' });
+```
+
+Use cases: typing indicators, live cursors, presence, any transient state that doesn't need persistence.
+
+### Entity feed
+
+Subscribe to **everything relevant to an entity** based on the mutual graph. This is the recommended approach for most apps.
+
+```ts
+const { isConnected, error } = useEntityFeed({
+  entityType: Entity.USER,
+  entityId: userId,
+});
+```
+
+When User A has a mutual with Channel X, and a new message is created in Channel X, User A receives the update automatically. No manual per-channel subscription needed.
+
+The feed hook:
+- Fetches a ticket via your proxy (or the default catch-all route)
+- Connects to WebSocket with the ticket
+- Routes all broadcast events into the entity and mutual stores
+- Refreshes the ticket before expiry
+- Resyncs via HTTP on reconnect
+
+::: tip
+`useEntityFeed` doesn't replace `useEntities` or `useMutuals` — it supplements them. Your existing hooks continue to work exactly as before. The feed just keeps their stores updated in real-time.
+:::
+
+## Entity Feed
+
+The entity feed deserves a deeper explanation since it's the primary way to add real-time updates to your app.
+
+### How it works
+
+1. Your app calls `useEntityFeed({ entityType: Entity.USER, entityId: userId })`
+2. The hook requests a **ticket** from monorise (via your proxy or the default route)
+3. The ticket carries the entity identity and allowed feed types
+4. The hook connects to WebSocket with the ticket
+5. The `$connect` handler validates the ticket and creates a feed subscription
+6. When any change happens in the mutual graph of that entity, the broadcast handler resolves affected feed subscribers and pushes the event
+
+### Default vs custom ticket endpoint
+
+This follows the same pattern as `customUrl` in `useEntities` and `useMutuals`:
+
+**Default (internal apps)** — goes through the catch-all proxy, no auth:
+
+```ts
+useEntityFeed({
+  entityType: Entity.USER,
+  entityId: userId,
+});
+```
+
+**Custom (client-facing apps)** — your own proxy route with auth:
+
+```ts
+useEntityFeed({
+  entityType: Entity.USER,
+  entityId: userId,
+  ticketEndpoint: '/api/ws/ticket',
+});
+```
+
+### Ticket proxy route
+
+For client-facing apps, create a proxy route that validates auth and issues a ticket:
+
+```ts
+// /api/ws/ticket/route.ts
+import { generateWebSocketTicket } from 'monorise/proxy';
+import { Entity } from './monorise/entities';
+
+export async function POST(req) {
+  const session = await getSession(req); // your auth
+  const { entityType, entityId } = await req.json();
+
+  // Your authorization logic
+  if (entityId !== session.userId) {
+    return Response.json({ error: 'forbidden' }, { status: 403 });
+  }
+
+  const ticket = await generateWebSocketTicket({
+    entityType,
+    entityId,
+    feedTypes: [Entity.CHANNEL, Entity.MESSAGE],
+  });
+
+  return Response.json(ticket);
+}
+```
+
+`generateWebSocketTicket()` handles the monorise API call internally. You control auth and which feed types each app gets.
+
+### Per-app feed control
+
+Different apps can issue tickets with different feed types:
+
+```ts
+// Client app — limited feed
+feedTypes: [Entity.CHANNEL, Entity.MESSAGE]
+
+// Admin app — full feed
+feedTypes: [Entity.CHANNEL, Entity.MESSAGE, Entity.AUDIT_LOG, Entity.PAYMENT]
+```
+
+The ticket carries the whitelist. The broadcast handler only pushes events for entity types in the whitelist.
+
+### Connection status
+
+```ts
+const { isConnected, error } = useEntityFeed({ ... });
+
+// isConnected: true when WebSocket is open
+// error?.code: 'TICKET_UNAUTHORIZED' | 'TICKET_FAILED' | 'CONNECTION_FAILED'
+```
+
+### Ticket refresh
+
+Tickets expire after 30 minutes. The hook refreshes proactively (2 minutes before expiry). If the proactive refresh fails, the server closes the connection on expiry and the hook reconnects with a fresh ticket.
+
+The developer never manages refresh. If the user's auth session expires, the proxy returns 401 and `error.code` becomes `'TICKET_UNAUTHORIZED'` — show a login screen.
+
+## DynamoDB Schema
+
+All WebSocket records live in the same single table as entities and mutuals, using consistent conventions:
+
+| Record | PK | SK |
+|--------|----|----|
+| Connection | `CONN#{connectionId}` | `#METADATA#` |
+| Ticket | `TICKET#{ticketId}` | `#METADATA#` |
+| Entity subscription | `SUB#ENTITY#{entityType}` | `CONN#{connectionId}` |
+| Mutual subscription | `SUB#MUTUAL#{byEntityType}#{byEntityId}#{entityType}` | `CONN#{connectionId}` |
+| Ephemeral subscription | `SUB#EPHEMERAL#{channel}` | `CONN#{connectionId}` |
+| Feed subscription | `SUB#FEED#{entityType}#{entityId}` | `CONN#{connectionId}` |
+
+All subscription records set `R1PK = CONN#{connectionId}` for reverse lookup on disconnect. Tickets use DynamoDB TTL (`expiresAt`) for automatic cleanup.
+
+## Connection Cleanup
+
+Three-layer strategy:
+
+1. **`$disconnect` handler** — queries R1 GSI by connectionId, deletes all subscription records in parallel
+2. **GoneException handling** — when broadcasting to a dead connection, the stale subscription record is deleted immediately
+3. **DynamoDB TTL** — connection and ticket records have `expiresAt` as a safety net for orphaned records
+
+## Architecture
+
+```
+Browser                     AWS
+───────                     ───
+
+useEntityFeed()
+  │
+  ├─ POST /api/.../ws/ticket ──► Hono Lambda ──► DynamoDB (TICKET#)
+  │  ◄── { ticket, wsUrl }
+  │
+  ├─ wss://wsUrl?ticket=... ──► API GW WebSocket
+  │                               │
+  │                               ├─ $connect ──► validate ticket
+  │                               │               create CONN# + SUB#FEED#
+  │                               │
+  │                               ├─ $default ──► route subscribe/ephemeral
+  │                               │
+  │                               └─ $disconnect ──► cleanup via R1 GSI
+  │
+  │  DynamoDB Stream ──► broadcast Lambda
+  │                        │
+  │                        ├─ entity change? ──► query SUB#ENTITY# subscribers
+  │                        ├─ mutual change? ──► query SUB#MUTUAL# subscribers
+  │                        └─ any change? ──► resolve SUB#FEED# via mutual graph
+  │
+  ◄── { type: 'entity.created', payload: ... }
+       (auto-updates zustand store)
+```

--- a/www/docs/websocket.md
+++ b/www/docs/websocket.md
@@ -85,6 +85,8 @@ Use cases: typing indicators, live cursors, presence, any transient state that d
 Subscribe to **everything relevant to an entity** based on the mutual graph. This is the recommended approach for most apps.
 
 ```ts
+import { useEntityFeed } from 'monorise/react';
+
 const { isConnected, error } = useEntityFeed({
   entityType: Entity.USER,
   entityId: userId,
@@ -121,7 +123,11 @@ The entity feed deserves a deeper explanation since it's the primary way to add 
 
 This follows the same pattern as `customUrl` in `useEntities` and `useMutuals`:
 
-**Default (internal apps)** — goes through the catch-all proxy, no auth:
+**Default (internal apps)** — goes through the catch-all proxy, no user-level auth (API key only):
+
+::: warning
+The default route issues tickets for any entity without user authentication. Use this only for local development and internal tooling. For client-facing apps, always use a custom `ticketEndpoint` with your own auth.
+:::
 
 ```ts
 useEntityFeed({


### PR DESCRIPTION
## Summary

Adds comprehensive WebSocket documentation to the VitePress docs site.

## Changes

### New page: `websocket.md`
- Enabling WebSocket in SST config
- All four subscription types (entity, mutual, ephemeral, feed) with code examples
- Entity feed deep dive: how it works, default vs custom ticket endpoint, proxy route setup, per-app feed control, connection status, ticket refresh
- DynamoDB schema table for all WebSocket record types
- Connection cleanup strategy (R1 GSI, GoneException, TTL)
- Architecture diagram (ASCII)

### Updated pages
- **VitePress config** — WebSocket added to top nav and sidebar under "SDKs & Packages"
- **packages.md** — Added `monorise/proxy` package, WebSocket hooks to React SDK description, repo path
- **sst.md** — Added `webSocket` config option and `websocket` resource to MonoriseCore docs
- **react.md** — Added WebSocket hooks reference table with link to WebSocket page

## Depends on

- #218 (all WebSocket features merged)

## Test plan

- [ ] Run `npm run docs:dev` and verify WebSocket page renders
- [ ] Verify nav and sidebar links work
- [ ] Verify code examples are syntax-highlighted
- [ ] Verify cross-links to WebSocket page from packages.md, sst.md, react.md