### PR TITLE
Fix ledger example build errors

### DIFF
--- a/.changeset/fix-ledger-build.md
+++ b/.changeset/fix-ledger-build.md
@@ -1,5 +1,6 @@
 ---
 "@monorise/base": patch
+"monorise": patch
 ---
 
 Fix MonoriseEntityConfig adjustmentConstraints minField/maxField defaulting to never when generic params are not specified

--- a/.changeset/fix-ledger-build.md
+++ b/.changeset/fix-ledger-build.md
@@ -1,0 +1,5 @@
+---
+"@monorise/base": patch
+---
+
+Fix MonoriseEntityConfig adjustmentConstraints minField/maxField defaulting to never when generic params are not specified

--- a/examples/ledger/apps/web/app/layout.tsx
+++ b/examples/ledger/apps/web/app/layout.tsx
@@ -3,6 +3,8 @@ import GlobalInitializer from '#/components/global-initializer';
 import GlobalLoader from '#/components/global-loader';
 import './globals.css';
 
+export const dynamic = 'force-dynamic';
+
 export const metadata: Metadata = {
   title: 'Ledger Dashboard',
   description: 'Monorise Ledger Example — Transaction management with DynamoDB',

--- a/examples/ledger/apps/web/components/buyer-summary.tsx
+++ b/examples/ledger/apps/web/components/buyer-summary.tsx
@@ -1,15 +1,10 @@
 'use client';
 
 import { useMemo } from 'react';
+import type { CreatedEntity } from 'monorise/base';
+import { Entity } from '#/monorise/entities';
 
-type Transaction = {
-  entityId: string;
-  data: {
-    amount: number;
-    type: 'sale' | 'refund' | 'discount';
-    [key: string]: any;
-  };
-};
+type Transaction = CreatedEntity<Entity.TRANSACTION>;
 
 function formatCurrency(cents: number) {
   return `$${(cents / 100).toFixed(2)}`;

--- a/examples/ledger/apps/web/components/merchant-line-chart.tsx
+++ b/examples/ledger/apps/web/components/merchant-line-chart.tsx
@@ -2,23 +2,11 @@
 
 import { useMemo, useState } from 'react';
 
-type Summary = {
-  entityId: string;
-  data: {
-    merchantId: string;
-    month: string;
-    totalSales: number;
-    totalRefunds: number;
-    totalDiscounts: number;
-    netTotal: number;
-    count: number;
-  };
-};
+import type { CreatedEntity } from 'monorise/base';
+import { Entity } from '#/monorise/entities';
 
-type Merchant = {
-  entityId: string;
-  data: { name: string; [key: string]: any };
-};
+type Summary = CreatedEntity<Entity.MONTHLY_SUMMARY>;
+type Merchant = CreatedEntity<Entity.MERCHANT>;
 
 function formatCompact(cents: number) {
   const val = cents / 100;

--- a/examples/ledger/apps/web/components/merchant-selector.tsx
+++ b/examples/ledger/apps/web/components/merchant-selector.tsx
@@ -1,11 +1,10 @@
 'use client';
 
 import { useState, useRef } from 'react';
+import type { CreatedEntity } from 'monorise/base';
+import { Entity } from '#/monorise/entities';
 
-type Merchant = {
-  entityId: string;
-  data: { name: string; [key: string]: any };
-};
+type Merchant = CreatedEntity<Entity.MERCHANT>;
 
 export default function MerchantSelector({
   merchants,

--- a/examples/ledger/apps/web/components/revenue-chart.tsx
+++ b/examples/ledger/apps/web/components/revenue-chart.tsx
@@ -1,16 +1,10 @@
 'use client';
 
 import { useMemo } from 'react';
+import type { CreatedEntity } from 'monorise/base';
+import { Entity } from '#/monorise/entities';
 
-type Transaction = {
-  entityId: string;
-  data: {
-    amount: number;
-    type: 'sale' | 'refund' | 'discount';
-    transactionDate: string;
-    [key: string]: any;
-  };
-};
+type Transaction = CreatedEntity<Entity.TRANSACTION>;
 
 type Granularity = 'daily' | 'monthly';
 

--- a/examples/ledger/apps/web/components/transaction-summary.tsx
+++ b/examples/ledger/apps/web/components/transaction-summary.tsx
@@ -1,15 +1,10 @@
 'use client';
 
 import { useMemo } from 'react';
+import type { CreatedEntity } from 'monorise/base';
+import { Entity } from '#/monorise/entities';
 
-type Transaction = {
-  entityId: string;
-  data: {
-    amount: number;
-    type: 'sale' | 'refund' | 'discount';
-    [key: string]: any;
-  };
-};
+type Transaction = CreatedEntity<Entity.TRANSACTION>;
 
 function formatCurrency(cents: number) {
   return `$${(cents / 100).toFixed(2)}`;

--- a/examples/ledger/apps/web/components/transaction-table.tsx
+++ b/examples/ledger/apps/web/components/transaction-table.tsx
@@ -1,21 +1,11 @@
 'use client';
 
 import { useEntity } from 'monorise/react';
+import type { CreatedEntity } from 'monorise/base';
 import { Entity } from '#/monorise/entities';
 import { Badge } from '#/components/ui/badge';
 
-type Transaction = {
-  entityId: string;
-  data: {
-    amount: number;
-    type: 'sale' | 'refund' | 'discount';
-    description?: string;
-    transactionDate: string;
-    status: string;
-    merchantId: string;
-    buyerId: string;
-  };
-};
+type Transaction = CreatedEntity<Entity.TRANSACTION>;
 
 function formatCurrency(cents: number) {
   return `$${(cents / 100).toFixed(2)}`;

--- a/examples/ledger/monorise/configs/buyer.ts
+++ b/examples/ledger/monorise/configs/buyer.ts
@@ -1,5 +1,5 @@
 import { createEntityConfig } from 'monorise/base';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { Entity } from '../entity';
 
 const baseSchema = z

--- a/examples/ledger/monorise/configs/merchant.ts
+++ b/examples/ledger/monorise/configs/merchant.ts
@@ -1,5 +1,5 @@
 import { createEntityConfig } from 'monorise/base';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { Entity } from '../entity';
 
 const baseSchema = z

--- a/examples/ledger/monorise/configs/transaction.ts
+++ b/examples/ledger/monorise/configs/transaction.ts
@@ -1,5 +1,5 @@
 import { createEntityConfig } from 'monorise/base';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import { Entity } from '../entity';
 
 const baseSchema = z

--- a/packages/base/types/monorise.type.ts
+++ b/packages/base/types/monorise.type.ts
@@ -261,9 +261,13 @@ export interface MonoriseEntityConfig<
       /** Field name on the entity whose value is used as the minimum (must be a numeric field) */
       minField?: keyof {
         [K in keyof B as B[K] extends z.ZodNumber | z.ZodOptional<z.ZodNumber> ? K : never]: K;
+      } extends never ? string : keyof {
+        [K in keyof B as B[K] extends z.ZodNumber | z.ZodOptional<z.ZodNumber> ? K : never]: K;
       };
       /** Field name on the entity whose value is used as the maximum (must be a numeric field) */
       maxField?: keyof {
+        [K in keyof B as B[K] extends z.ZodNumber | z.ZodOptional<z.ZodNumber> ? K : never]: K;
+      } extends never ? string : keyof {
         [K in keyof B as B[K] extends z.ZodNumber | z.ZodOptional<z.ZodNumber> ? K : never]: K;
       };
     };


### PR DESCRIPTION
## Summary
- Fix `zod/v4` imports to `zod` in entity configs (buyer, merchant, transaction) — zod v4 subpath exports incompatible types with monorise's zod v3 base
- Replace local Transaction/Merchant/Summary types with `CreatedEntity<T>` from `monorise/base` to match actual schema types
- Add `force-dynamic` to root layout to prevent SSG prerender errors
- Fix `MonoriseEntityConfig` `adjustmentConstraints` `minField`/`maxField` defaulting to `never` when generic params are not specified

## Test plan
- [x] `npm run build` passes in `examples/ledger/apps/web`
- [x] Deployed to demo stage successfully
- [x] Seeded with 10 merchants, 1,000 buyers, ~9,000 transactions