### PR TITLE
fix(changeset): remove @monorise/proxy from upgrade-sst-v4 changeset

### DIFF
--- a/.changeset/upgrade-sst-v4.md
+++ b/.changeset/upgrade-sst-v4.md
@@ -2,7 +2,6 @@
 "@monorise/base": major
 "@monorise/cli": major
 "@monorise/core": major
-"@monorise/proxy": major
 "@monorise/react": major
 "@monorise/sst": major
 "monorise": major


### PR DESCRIPTION
The release action is failing because `@monorise/proxy` does not exist in the main workspace yet (it was introduced as part of websocket features). This removes it from the changeset so the release can proceed.