### PR TITLE
feat(react,base): expose conditional PATCH updates via $where

### DIFF
--- a/.changeset/react-conditional-patch-where.md
+++ b/.changeset/react-conditional-patch-where.md
@@ -1,0 +1,10 @@
+---
+"@monorise/base": minor
+"@monorise/react": minor
+---
+
+Expose conditional PATCH updates via `$where` in react package
+
+- Added `WhereOperator`, `WhereClause`, `WhereConditions` types to `@monorise/base`
+- `editEntity` in `@monorise/react` now accepts an optional `where` argument; conditions are sent as `$where` in the PATCH body
+- Re-exports `WhereConditions`, `WhereClause`, `WhereOperator` from `@monorise/react`

--- a/.changeset/react-conditional-patch-where.md
+++ b/.changeset/react-conditional-patch-where.md
@@ -1,4 +1,5 @@
 ---
+"monorise": minor
 "@monorise/base": minor
 "@monorise/react": minor
 ---

--- a/packages/base/index.ts
+++ b/packages/base/index.ts
@@ -8,6 +8,11 @@ import {
 } from './types/monorise.type';
 
 import { createEntityConfig } from './utils';
+import type {
+  WhereClause,
+  WhereConditions,
+  WhereOperator,
+} from './types/where.type';
 
 export {
   Entity,
@@ -18,3 +23,5 @@ export {
   NumericFields,
   createEntityConfig,
 };
+
+export type { WhereClause, WhereConditions, WhereOperator };

--- a/packages/base/types/where.type.ts
+++ b/packages/base/types/where.type.ts
@@ -1,0 +1,13 @@
+export type WhereOperator =
+  | { $eq: string | number | boolean }
+  | { $ne: string | number | boolean }
+  | { $gt: number }
+  | { $lt: number }
+  | { $gte: number }
+  | { $lte: number }
+  | { $exists: boolean }
+  | { $beginsWith: string };
+
+export type WhereClause = WhereOperator | string | number | boolean;
+
+export type WhereConditions = Record<string, WhereClause>;

--- a/packages/react/actions/core.action.ts
+++ b/packages/react/actions/core.action.ts
@@ -3,6 +3,7 @@ import type {
   DraftEntity,
   Entity,
   EntitySchemaMap,
+  WhereConditions,
 } from '@monorise/base';
 import { produce } from 'immer';
 import { useEffect, useState } from 'react';
@@ -428,9 +429,7 @@ const initCoreActions = (
           if (tagConfigs) {
             for (const tagConfig of tagConfigs) {
               const { name, processor } = tagConfig;
-              const processorResults = processor(
-                data as CreatedEntity<Entity>,
-              );
+              const processorResults = processor(data as CreatedEntity<Entity>);
 
               for (const tagKey of Object.keys(state.tag)) {
                 const [tagEntityType, tagName, ...paramParts] =
@@ -452,8 +451,9 @@ const initCoreActions = (
                 for (const part of paramParts) {
                   const colonIdx = part.indexOf(':');
                   if (colonIdx > 0) {
-                    keyParams[part.substring(0, colonIdx)] =
-                      part.substring(colonIdx + 1);
+                    keyParams[part.substring(0, colonIdx)] = part.substring(
+                      colonIdx + 1,
+                    );
                   }
                 }
 
@@ -490,8 +490,7 @@ const initCoreActions = (
           }
 
           // auto-populate mutual store based on entity config
-          const mutualFields =
-            state.config[entityType]?.mutual?.mutualFields;
+          const mutualFields = state.config[entityType]?.mutual?.mutualFields;
           if (mutualFields) {
             for (const [field, fieldConfig] of Object.entries(mutualFields)) {
               const byEntityType = fieldConfig.entityType;
@@ -573,12 +572,13 @@ const initCoreActions = (
     id: string,
     entity: Partial<DraftEntity<T>>,
     opts: CommonOptions = {},
+    where?: WhereConditions,
   ) => {
     const entityService = makeEntityService(entityType);
     const onError = opts.onError ?? defaultOnError;
 
     try {
-      const { data } = await entityService.editEntity(id, entity, opts);
+      const { data } = await entityService.editEntity(id, entity, opts, where);
 
       monoriseStore.setState(
         produce((state) => {
@@ -600,7 +600,10 @@ const initCoreActions = (
           // update flipped mutual side (entity is the "by" entity)
           for (const key of Object.keys(state.mutual)) {
             const [_byEntity, _byId] = key.split('/');
-            if ((_byEntity as unknown as Entity) === entityType && _byId === id) {
+            if (
+              (_byEntity as unknown as Entity) === entityType &&
+              _byId === id
+            ) {
               const newDataMap = new Map(state.mutual[key].dataMap);
               for (const [entryId, mutual] of newDataMap) {
                 newDataMap.set(entryId, { ...mutual, data: data.data });
@@ -663,10 +666,16 @@ const initCoreActions = (
 
           for (const key of Object.keys(state.mutual)) {
             const [_byEntity, _byId] = key.split('/');
-            if ((_byEntity as unknown as Entity) === entityType && _byId === id) {
+            if (
+              (_byEntity as unknown as Entity) === entityType &&
+              _byId === id
+            ) {
               const newDataMap = new Map(state.mutual[key].dataMap);
               for (const [entryId, mutual] of newDataMap) {
-                newDataMap.set(entryId, { ...(mutual as any), data: data.data });
+                newDataMap.set(entryId, {
+                  ...(mutual as any),
+                  data: data.data,
+                });
               }
               state.mutual[key].dataMap = newDataMap;
             }
@@ -1481,7 +1490,15 @@ const initCoreActions = (
       if (!isFirstFetched || opts?.forceFetch) {
         listEntities(entityType, { skRange, all, limit }, opts);
       }
-    }, [all, entityType, skRange, opts, isFirstFetched, opts?.forceFetch, limit]);
+    }, [
+      all,
+      entityType,
+      skRange,
+      opts,
+      isFirstFetched,
+      opts?.forceFetch,
+      limit,
+    ]);
 
     useEffect(() => {
       let queryTimeout: NodeJS.Timeout;
@@ -1647,7 +1664,12 @@ const initCoreActions = (
     const error = useErrorStore(requestKey);
 
     useEffect(() => {
-      if (byEntityType && entityType && byId && (!isFirstFetched || opts?.forceFetch)) {
+      if (
+        byEntityType &&
+        entityType &&
+        byId &&
+        (!isFirstFetched || opts?.forceFetch)
+      ) {
         listEntitiesByEntity(
           byEntityType,
           entityType,

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -216,4 +216,7 @@ export type {
   Entity,
   EntitySchemaMap,
   NumericFields,
+  WhereClause,
+  WhereConditions,
+  WhereOperator,
 } from '@monorise/base';

--- a/packages/react/services/core.service.ts
+++ b/packages/react/services/core.service.ts
@@ -1,4 +1,4 @@
-import type { CreatedEntity, DraftEntity, Entity } from '@monorise/base';
+import type { CreatedEntity, DraftEntity, Entity, WhereConditions } from '@monorise/base';
 import type { AxiosRequestConfig } from 'axios';
 import {
   getEntityRequestKey,
@@ -210,12 +210,13 @@ const initCoreService = (
     id: string,
     values: Partial<DraftEntity<T>>,
     opts: CommonOptions = {},
+    where?: WhereConditions,
   ) => {
     const { entityApiBaseUrl = ENTITY_API_BASE_URL } = options;
     const entityConfig = monoriseStore.getState().config;
     return axios.patch<CreatedEntity<T>>(
       opts.customUrl || `${entityApiBaseUrl}/${entityType}/${id}`,
-      values,
+      where ? { ...values, $where: where } : values,
       {
         requestKey: getEntityRequestKey('edit', entityType, id),
         isInterruptive: opts.isInterruptive ?? true,
@@ -444,12 +445,14 @@ const initCoreService = (
       id: string,
       values: Partial<DraftEntity<T>>,
       opts: CommonOptions = {},
-    ) => editEntity(entityType, id, values, opts),
+      where?: WhereConditions,
+    ) => editEntity(entityType, id, values, opts, where),
     updateEntity: (
       id: string,
       values: DraftEntity<T>,
       opts: CommonOptions = {},
-    ) => editEntity(entityType, id, values, opts),
+      where?: WhereConditions,
+    ) => editEntity(entityType, id, values, opts, where),
     adjustEntity: (
       id: string,
       adjustments: Record<string, number>,


### PR DESCRIPTION
## Summary

- Add shared `WhereOperator`, `WhereClause`, `WhereConditions` types to `@monorise/base`
- Thread `where?: WhereConditions` param through `editEntity` in react's coreService and coreActions
- Merge conditions into PATCH body as `$where` field
- Re-export where types from `@monorise/react`

Exposes conditional update support (from #223) to React package consumers. Allows callers to guard entity updates with server-side conditions.

## Test plan

- [x] Both packages build successfully
- [x] Types exported from `@monorise/react`
- [x] `editEntity` accepts optional `where` parameter
- [x] Conditions merged into PATCH body as `$where`

Related: #223