### PR TITLE
fix(changeset): remove @monorise/react from upgrade-sst-v4 changeset

### DIFF
--- a/.changeset/upgrade-sst-v4.md
+++ b/.changeset/upgrade-sst-v4.md
@@ -2,7 +2,6 @@
 "@monorise/base": major
 "@monorise/cli": major
 "@monorise/core": major
-"@monorise/react": major
 "@monorise/sst": major
 "monorise": major
 ---


### PR DESCRIPTION
Prevents `@monorise/react` from being forced to a major bump (which would jump to v5) by the SST v4 changeset. The react package has no actual code changes in this upgrade.