### PR TITLE
feat: add MutualDataMapping codegen and duplicate detection

### DIFF
--- a/packages/cli/commands/utils/generate.ts
+++ b/packages/cli/commands/utils/generate.ts
@@ -13,6 +13,50 @@ function kebabToPascal(kebab: string): string {
     .join('');
 }
 
+function generateMutualDataMappingDeclarations(
+  mutualPairs: {
+    byEnumKey: string;
+    entityEnumKey: string;
+    variableName: string;
+    fieldKey: string;
+  }[],
+): string {
+  if (mutualPairs.length === 0) return '';
+
+  // Group by byEnumKey → { entityEnumKey: schemaPath }
+  const grouped = new Map<string, string[]>();
+  for (const pair of mutualPairs) {
+    const schemaPath = `z.infer<(typeof ${pair.variableName})['mutual']['mutualFields']['${pair.fieldKey}']['mutual']['mutualDataSchema']>`;
+    const entry = `[Entity.${pair.entityEnumKey}]: ${schemaPath};`;
+    if (!grouped.has(pair.byEnumKey)) {
+      grouped.set(pair.byEnumKey, []);
+    }
+    grouped.get(pair.byEnumKey)!.push(entry);
+  }
+
+  const mappingEntries = Array.from(grouped.entries())
+    .map(
+      ([enumKey, entries]) =>
+        `    [Entity.${enumKey}]: {\n      ${entries.join('\n      ')}\n    };`,
+    )
+    .join('\n');
+
+  const block = `
+  export interface MutualDataMapping {
+${mappingEntries}
+  }`;
+
+  return `
+declare module '@monorise/react' {
+${block}
+}
+
+declare module 'monorise/react' {
+${block}
+}
+`;
+}
+
 async function generateConfigFile(
   configDir: string,
   monoriseOutputDir: string,
@@ -38,6 +82,19 @@ export enum Entity {}
   const schemaEntries: string[] = [];
   const allowedEntityEntries: string[] = [];
   const entityWithEmailAuthEntries: string[] = [];
+
+  // Track mutual pairs for MutualDataMapping codegen and duplicate detection
+  // Each entry: { byEnumKey, entityEnumKey, variableName, fieldKey, mutualRef }
+  const mutualPairs: {
+    byEnumKey: string;
+    entityEnumKey: string;
+    variableName: string;
+    fieldKey: string;
+    mutualRef: any;
+    file: string;
+  }[] = [];
+  // Map of normalized pair key → first seen mutualRef for duplicate detection
+  const seenMutualPairs = new Map<string, { mutualRef: any; file: string; fieldKey: string }>();
 
   const relativePathToConfigDir = path.relative(monoriseOutputDir, configDir);
   const importPathPrefix = relativePathToConfigDir
@@ -84,6 +141,37 @@ export enum Entity {}
 
     if (config.authMethod?.email) {
       entityWithEmailAuthEntries.push(`Entity.${enumKey}`);
+    }
+
+    // Collect mutual pairs for codegen and duplicate detection
+    if (config.mutual?.mutualFields) {
+      for (const [fieldKey, fieldConfig] of Object.entries(config.mutual.mutualFields) as [string, any][]) {
+        if (fieldConfig.mutual?.mutualDataSchema) {
+          const targetName = fieldConfig.entityType as string;
+          const entityEnumKey = targetName.toUpperCase().replace(/-/g, '_');
+
+          // Duplicate detection: normalize pair alphabetically
+          const pairKey = [config.name, targetName].sort().join('::');
+          const existing = seenMutualPairs.get(pairKey);
+          if (existing && existing.mutualRef !== fieldConfig.mutual) {
+            throw new Error(
+              `Conflicting mutual configs for entity pair [${config.name}, ${targetName}]: ` +
+              `found in ${file} (field: ${fieldKey}) and ${existing.file} (field: ${existing.fieldKey}). ` +
+              `Use the same createMutualConfig instance for both sides.`,
+            );
+          }
+          seenMutualPairs.set(pairKey, { mutualRef: fieldConfig.mutual, file, fieldKey });
+
+          mutualPairs.push({
+            byEnumKey: enumKey,
+            entityEnumKey,
+            variableName,
+            fieldKey,
+            mutualRef: fieldConfig.mutual,
+            file,
+          });
+        }
+      }
     }
   }
 
@@ -154,6 +242,7 @@ declare module 'monorise/base' {
     ${schemaMapEntries.join('\n    ')}
   }
 }
+${generateMutualDataMappingDeclarations(mutualPairs)}
 `;
 
   fs.writeFileSync(configOutputPath, configOutputContent);

--- a/packages/core/services/__tests__/mutual-data-schema.test.ts
+++ b/packages/core/services/__tests__/mutual-data-schema.test.ts
@@ -207,6 +207,76 @@ describe('MutualService schema validation integration', () => {
     ).resolves.toBeDefined();
   });
 
+  it('should reject invalid mutualPayload in createMutual with reversed entity pair', async () => {
+    const mockEntityRepo = {
+      getEntity: async () => ({ data: {} }),
+    };
+    const mockMutualRepo = {
+      checkMutualExist: async () => {},
+      createMutualTransactItems: () => [],
+    };
+    const mockDdbUtils = {
+      executeTransactWrite: async () => {},
+    };
+    const mockPublishEvent = async () => {};
+    const mockLifecycle = {};
+
+    const service = new MutualService(
+      mockEntityConfig,
+      mockEntityRepo as any,
+      mockMutualRepo as any,
+      mockPublishEvent as any,
+      mockDdbUtils as any,
+      mockLifecycle as any,
+    );
+
+    // Reversed: COURSE as byEntityType, STUDENT as entityType
+    await expect(
+      service.createMutual({
+        byEntityType: TestEntity.COURSE as unknown as EntityType,
+        byEntityId: 'course-1',
+        entityType: TestEntity.STUDENT as unknown as EntityType,
+        entityId: 'student-1',
+        mutualPayload: { role: 'invalid-role', enrolledAt: '2026-01-01' },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('should accept valid mutualPayload in createMutual with reversed entity pair', async () => {
+    const mockEntityRepo = {
+      getEntity: async () => ({ data: {} }),
+    };
+    const mockMutualRepo = {
+      checkMutualExist: async () => {},
+      createMutualTransactItems: () => [],
+    };
+    const mockDdbUtils = {
+      executeTransactWrite: async () => {},
+    };
+    const mockPublishEvent = async () => {};
+    const mockLifecycle = {};
+
+    const service = new MutualService(
+      mockEntityConfig,
+      mockEntityRepo as any,
+      mockMutualRepo as any,
+      mockPublishEvent as any,
+      mockDdbUtils as any,
+      mockLifecycle as any,
+    );
+
+    // Reversed: COURSE as byEntityType, STUDENT as entityType
+    await expect(
+      service.createMutual({
+        byEntityType: TestEntity.COURSE as unknown as EntityType,
+        byEntityId: 'course-1',
+        entityType: TestEntity.STUDENT as unknown as EntityType,
+        entityId: 'student-1',
+        mutualPayload: { role: 'auditor', enrolledAt: '2026-01-01' },
+      }),
+    ).resolves.toBeDefined();
+  });
+
   it('should allow any payload when no mutualDataSchema defined', async () => {
     const mockEntityRepo = {
       getEntity: async () => ({ data: {} }),


### PR DESCRIPTION
## Summary

Cherry-picked from #240. Adds on top of the `createMutualConfig` feature already merged via #241:

- Codegen `MutualDataMapping` augmentation in `generate.ts` for both `@monorise/react` and `monorise/react`, enabling frontend type narrowing for `mutualData` based on entity pair
- Build-time duplicate detection for conflicting `createMutualConfig` instances targeting the same entity pair
- Reversed entity pair tests for `MutualService` schema validation

## Why

Without codegen, `MutualData<B, T>` always resolves to `Record<string, any>` on the frontend — no compile-time type safety. With this change, defining `mutualDataSchema` via `createMutualConfig` automatically narrows the payload type in React hooks and actions.

Duplicate detection prevents silent conflicts when two different `createMutualConfig` instances target the same entity pair.

## Test plan

- [x] 12 unit tests pass (including reversed entity pair)
- [x] Build passes (proxy error pre-existing, unrelated)
- [ ] Verify generated `config.ts` includes `MutualDataMapping` augmentation in a consumer project