### PR TITLE
chore: add changeset for createMutualConfig

### DIFF
--- a/.changeset/mutual-config-codegen.md
+++ b/.changeset/mutual-config-codegen.md
@@ -1,0 +1,7 @@
+---
+"@monorise/base": minor
+"@monorise/core": minor
+"monorise": minor
+---
+
+Add `createMutualConfig` for centralized mutualData schema validation. Codegen `MutualDataMapping` for frontend type narrowing. Build-time duplicate detection for conflicting mutual configs.


### PR DESCRIPTION
## Summary

- Add missing changeset for the `createMutualConfig` feature merged in #243

Minor bump for `@monorise/base`, `@monorise/core`, and `monorise`.