### PR TITLE
feat(sst): support reusing existing DynamoDB table in SingleTable

### DIFF
--- a/.changeset/ten-birds-drum.md
+++ b/.changeset/ten-birds-drum.md
@@ -1,0 +1,5 @@
+---
+"@monorise/sst": patch
+---
+
+feat(sst): support reusing existing DynamoDB table in SingleTable

--- a/packages/sst/components/monorise-core.ts
+++ b/packages/sst/components/monorise-core.ts
@@ -6,6 +6,7 @@ import { SingleTable } from './single-table';
 
 type MonoriseCoreArgs = {
   tableTtl?: string;
+  fromTableName?: $util.Input<string>;
   slackWebhook?: string;
   allowHeaders?: string[];
   allowOrigins?: string[];
@@ -53,6 +54,7 @@ export class MonoriseCore {
       ttl: args?.tableTtl,
       runtime,
       configRoot: args?.configRoot,
+      fromTableName: args?.fromTableName,
     });
 
     const secretApiKeys = new sst.Secret('API_KEYS', '["secret1", "secret2"]');

--- a/packages/sst/components/single-table.ts
+++ b/packages/sst/components/single-table.ts
@@ -13,7 +13,7 @@ type SingleTableArgs = {
    * The table must already have DynamoDB Streams enabled with NEW_AND_OLD_IMAGES
    * and the GSIs (R1, R2) expected by monorise.
    */
-  existingTableName?: $util.Input<string>;
+  fromTableName?: $util.Input<string>;
 };
 
 export class SingleTable {
@@ -26,8 +26,8 @@ export class SingleTable {
     this.id = id;
     this.replicatorFunctionName = `${$app.stage}-${$app.name}-${id}-core-replicator`;
     this.dlq = new sst.aws.Queue(`${id}-core-replicator-dlq`);
-    this.table = args?.existingTableName
-      ? sst.aws.Dynamo.get(`${id}-core-table`, args.existingTableName)
+    this.table = args?.fromTableName
+      ? sst.aws.Dynamo.get(`${id}-core-table`, args.fromTableName)
       : new sst.aws.Dynamo(`${id}-core-table`, {
           fields: {
             PK: 'string',

--- a/packages/sst/components/single-table.ts
+++ b/packages/sst/components/single-table.ts
@@ -8,6 +8,12 @@ type SingleTableArgs = {
   ttl?: string;
   runtime?: sst.aws.FunctionArgs['runtime'];
   configRoot?: string;
+  /**
+   * Name of an existing DynamoDB table to use instead of creating a new one.
+   * The table must already have DynamoDB Streams enabled with NEW_AND_OLD_IMAGES
+   * and the GSIs (R1, R2) expected by monorise.
+   */
+  existingTableName?: $util.Input<string>;
 };
 
 export class SingleTable {
@@ -20,45 +26,47 @@ export class SingleTable {
     this.id = id;
     this.replicatorFunctionName = `${$app.stage}-${$app.name}-${id}-core-replicator`;
     this.dlq = new sst.aws.Queue(`${id}-core-replicator-dlq`);
-    this.table = new sst.aws.Dynamo(`${id}-core-table`, {
-      fields: {
-        PK: 'string',
-        SK: 'string',
-        R1PK: 'string',
-        R1SK: 'string',
-        R2PK: 'string',
-        R2SK: 'string',
-      },
-      primaryIndex: { hashKey: 'PK', rangeKey: 'SK' },
-      globalIndexes: {
-        [ENTITY_REPLICATION_INDEX]: {
-          hashKey: 'R1PK',
-          rangeKey: 'R1SK',
-          projection: [
-            'PK',
-            'SK',
-            'R2PK',
-            'R2SK',
-            'updatedAt',
-            'mutualUpdatedAt',
-          ],
-        },
-        [MUTUAL_REPLICATION_INDEX]: {
-          hashKey: 'R2PK',
-          rangeKey: 'R2SK',
-          projection: [
-            'PK',
-            'SK',
-            'R2PK',
-            'R2SK',
-            'updatedAt',
-            'mutualUpdatedAt',
-          ],
-        },
-      },
-      stream: 'new-and-old-images',
-      ttl: args?.ttl,
-    });
+    this.table = args?.existingTableName
+      ? sst.aws.Dynamo.get(`${id}-core-table`, args.existingTableName)
+      : new sst.aws.Dynamo(`${id}-core-table`, {
+          fields: {
+            PK: 'string',
+            SK: 'string',
+            R1PK: 'string',
+            R1SK: 'string',
+            R2PK: 'string',
+            R2SK: 'string',
+          },
+          primaryIndex: { hashKey: 'PK', rangeKey: 'SK' },
+          globalIndexes: {
+            [ENTITY_REPLICATION_INDEX]: {
+              hashKey: 'R1PK',
+              rangeKey: 'R1SK',
+              projection: [
+                'PK',
+                'SK',
+                'R2PK',
+                'R2SK',
+                'updatedAt',
+                'mutualUpdatedAt',
+              ],
+            },
+            [MUTUAL_REPLICATION_INDEX]: {
+              hashKey: 'R2PK',
+              rangeKey: 'R2SK',
+              projection: [
+                'PK',
+                'SK',
+                'R2PK',
+                'R2SK',
+                'updatedAt',
+                'mutualUpdatedAt',
+              ],
+            },
+          },
+          stream: 'new-and-old-images',
+          ttl: args?.ttl,
+        });
 
     const environment = {
       CORE_TABLE: this.table.name,


### PR DESCRIPTION
## Summary

- Add optional `fromTableName` arg to `SingleTable` in `@monorise/sst`, surfaced through `MonoriseCore` as well
- When provided, the component looks up the table via `sst.aws.Dynamo.get(...)` instead of creating a new one
- DLQ creation and the replicator stream subscription remain unchanged, so the same `subscribe(...)` wiring runs against the existing table

## Why

Some deployments need monorise's replicator wiring against a DynamoDB table that already exists outside the current SST stack — e.g. a table provisioned by another stack, by Terraform, or shared across stages. Previously `SingleTable` would always try to create a new table, making this impossible without forking the component.

This adds an opt-in lookup path. Behavior is unchanged when `fromTableName` is not set.

### Caller responsibility

When passing an existing table, the caller must ensure the table already has:

- DynamoDB Streams enabled with `NEW_AND_OLD_IMAGES`
- The `R1` and `R2` GSIs expected by monorise (hash/range on `R1PK`/`R1SK` and `R2PK`/`R2SK`)

`Dynamo.get(...)` is a read-only reference, so SST cannot enforce or change these — they're documented in the JSDoc on the new arg.

## Usage

Via `MonoriseCore` (typical entry point):

```ts
new MonoriseCore('my-app', {
  fromTableName: 'my-app-core-table',
});
```

Or directly on `SingleTable`:

```ts
new SingleTable('my-app', {
  fromTableName: 'my-app-core-table',
});
```

`fromTableName` accepts `Input<string>`, so an `Output<string>` from another stack reference also works.

## Test plan

- [ ] Deploy a stack with `fromTableName` pointing at an existing table — confirm no new table is created and the replicator function is wired to the existing table's stream
- [ ] Deploy a stack without `fromTableName` — confirm behavior is unchanged (new table created with both GSIs and stream)
- [ ] Trigger a write on the existing table and confirm the replicator processes the event