### PR TITLE
fix(base): restore export on Entity enum in bundled .d.ts

### DIFF
--- a/.changeset/fix-entity-enum-export.md
+++ b/.changeset/fix-entity-enum-export.md
@@ -1,0 +1,6 @@
+---
+"@monorise/base": patch
+"monorise": patch
+---
+
+Fix Entity enum `declare module` augmentation by restoring `export` on the enum declaration in bundled `.d.ts` output. The tsup DTS bundler was stripping `export` from `export declare enum Entity {}`, which broke TypeScript module augmentation for consumer projects.

--- a/packages/base/fix-dts.cjs
+++ b/packages/base/fix-dts.cjs
@@ -1,0 +1,14 @@
+// Post-build fix: tsup DTS bundling converts `export declare enum` to
+// `declare enum` + re-export, which breaks `declare module` augmentation.
+// This script restores `export` on the Entity enum declaration and removes
+// the duplicate from the re-export statement.
+const fs = require('fs');
+const p = 'dist/index.d.ts';
+let content = fs.readFileSync(p, 'utf-8');
+// Add export to enum declaration
+content = content.replace(/^declare enum Entity \{/m, 'export declare enum Entity {');
+// Remove Entity from the re-export line (now exported on declaration)
+// Handles: `Entity, ` or `, Entity` patterns — only match standalone Entity, not CreatedEntity etc.
+content = content.replace(/\bEntity,\s*(?=type\b)/g, '');
+content = content.replace(/,\s*Entity\b(?![\w])/g, '');
+fs.writeFileSync(p, content);

--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -9,7 +9,7 @@
     "lib": "lib"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node fix-dts.cjs",
     "dev": "tsup --watch"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary

- Add post-build script (`fix-dts.cjs`) to restore `export` on the `Entity` enum declaration in the bundled `.d.ts` output

## Why

When the build tool switched from `tsc` to `tsup` in #173, the bundled DTS output changed from `export declare enum Entity {}` to `declare enum Entity {}` + re-export via `export { Entity }`. This broke `declare module` augmentation in consumer projects — TypeScript couldn't merge augmented enum members into the non-exported declaration, causing `Type 'Entity.X' is not assignable to type 'Entity'` errors.

This affected both `@monorise/base` (individual) and `monorise/base` (combined package) consumers.

## Test plan

- [x] `npm run build` passes
- [x] Verified fix via `npm pack` + install in consumer project (shapeos) — Entity assignability errors resolved
- [x] Verified `dist/index.d.ts` has `export declare enum Entity {}` and clean `export {}` statement