### PR TITLE
fix: loosen sst peer dep from exact 4.7.3 to ^4.7.3

### DIFF
--- a/.changeset/fix-sst-peer-dep.md
+++ b/.changeset/fix-sst-peer-dep.md
@@ -1,0 +1,6 @@
+---
+"@monorise/sst": patch
+"monorise": patch
+---
+
+Loosen sst peer dependency from exact `4.7.3` to `^4.7.3` to allow newer minor/patch versions.

--- a/packages/monorise/package.json
+++ b/packages/monorise/package.json
@@ -99,7 +99,7 @@
     "hono": "^4.7.10",
     "react": "^19",
     "react-dom": "^19",
-    "sst": "4.7.3"
+    "sst": "^4.7.3"
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.147",

--- a/packages/sst/package.json
+++ b/packages/sst/package.json
@@ -23,7 +23,7 @@
     "nanoid": "^5.1.3"
   },
   "peerDependencies": {
-    "sst": "4.7.3"
+    "sst": "^4.7.3"
   },
   "devDependencies": {
     "@types/aws-lambda": "8.10.149"


### PR DESCRIPTION
## Summary

- Loosen `sst` peer dependency from exact `4.7.3` to `^4.7.3` in `@monorise/sst` and `monorise` packages
- Prevents `npm ERESOLVE` errors when consumer projects use newer sst versions

Mirrors #248 (main branch) without the example file changes.

## Test plan

- [x] `npm run build` passes
- [ ] Consumer project `npm install` works without `--force`