### PR TITLE
fix: add missing AWS SDK deps for WebSocket support

### DIFF
--- a/packages/monorise/package.json
+++ b/packages/monorise/package.json
@@ -81,7 +81,9 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.758.0",
     "@aws-sdk/client-dynamodb-streams": "^3.758.0",
+    "@aws-sdk/client-apigatewaymanagementapi": "^3.758.0",
     "@aws-sdk/client-eventbridge": "^3.758.0",
+    "@aws-sdk/lib-dynamodb": "^3.758.0",
     "@aws-sdk/util-dynamodb": "^3.758.0",
     "axios": "^1.8.1",
     "chokidar": "^4.0.3",


### PR DESCRIPTION
Fixes missing `@aws-sdk/client-apigatewaymanagementapi` and `@aws-sdk/lib-dynamodb` dependencies in the unified monorise package.

These dependencies were added to `@monorise/core` in the WebSocket PR but were missing from the unified `monorise` package, causing build errors when consumers import WebSocket handlers.