### PR TITLE
feat(sst): add link prop to MonoriseCoreArgs

### DIFF
--- a/.changeset/sharp-planes-arrive.md
+++ b/.changeset/sharp-planes-arrive.md
@@ -1,0 +1,6 @@
+---
+"@monorise/sst": minor
+"monorise": minor
+---
+
+Add link prop to MonoriseCoreArgs to forward extra SST links to the app handler Lambda

--- a/packages/sst/components/monorise-core.ts
+++ b/packages/sst/components/monorise-core.ts
@@ -11,6 +11,7 @@ type MonoriseCoreArgs = {
   allowHeaders?: string[];
   allowOrigins?: string[];
   configRoot?: string;
+  link?: $util.Input<any[]>;
 };
 
 export class MonoriseCore {
@@ -63,7 +64,7 @@ export class MonoriseCore {
     this.api.route('ANY /core/{proxy+}', {
       name: appHandlerName,
       handler: `${dotMonorisePath}/handle.appHandler`,
-      link: [this.table.table, this.bus, secretApiKeys],
+      link: [this.table.table, this.bus, secretApiKeys, ...(args?.link ?? [])],
       environment: {
         API_KEYS: secretApiKeys.value,
         CORE_TABLE: this.table.table.name,


### PR DESCRIPTION
## Why

`MonoriseCore` wires the app handler Lambda with its own resources (DynamoDB table, EventBridge bus, API keys), but there was no way to inject external SST resources into that Lambda. This blocked custom routes from consuming resources that live outside monorise — e.g. third-party API secrets, S3 buckets, or other SST components.

## What changed

Added a `link` prop to `MonoriseCoreArgs`. Any resources passed are appended to the app handler Lambda's existing link array alongside the hardcoded monorise resources.

The internal event processors (mutual, tag, tree) are unaffected — they don't run custom route code.

## Usage

```typescript
// sst.config.ts
const stripeSecret = new sst.Secret('StripeWebhookSecret')

new monorise.module.Core('app', {
  link: [stripeSecret],
})
```

```typescript
// src/routes.ts (custom routes)
import { Resource } from 'sst'

export default (container: DependencyContainer) => {
  const app = new Hono()

  app.post('/webhooks/stripe', async (c) => {
    const secret = Resource.StripeWebhookSecret.value
    // ...
  })

  return app
}
```

## Test plan

- [ ] Deploy with a `sst.Secret` passed via `link` — verify `Resource.*` is accessible in custom route handler
- [ ] Deploy without `link` — verify existing behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)