### PR TITLE
Feat dev/monorise core link support

### DIFF
--- a/.changeset/sharp-planes-arrive.md
+++ b/.changeset/sharp-planes-arrive.md
@@ -1,0 +1,6 @@
+---
+"@monorise/sst": minor
+"monorise": minor
+---
+
+Add link prop to MonoriseCoreArgs to forward extra SST links to the app handler Lambda

--- a/packages/sst/components/monorise-core.ts
+++ b/packages/sst/components/monorise-core.ts
@@ -21,6 +21,7 @@ type MonoriseCoreArgs = {
   allowOrigins?: string[];
   configRoot?: string;
   webSocket?: WebSocketConfig;
+  link?: $util.Input<any[]>;
 };
 
 export class MonoriseCore {
@@ -76,6 +77,16 @@ export class MonoriseCore {
       CORE_EVENT_BUS: this.bus.name,
     };
     const appHandlerLinks: any[] = [this.table.table, this.bus, secretApiKeys];
+    this.api.route('ANY /core/{proxy+}', {
+      name: appHandlerName,
+      handler: `${dotMonorisePath}/handle.appHandler`,
+      link: [this.table.table, this.bus, secretApiKeys, ...(args?.link ?? [])],
+      environment: {
+        API_KEYS: secretApiKeys.value,
+        CORE_TABLE: this.table.table.name,
+        CORE_EVENT_BUS: this.bus.name,
+      },
+    });
 
     this.alarmTopic = new sst.aws.SnsTopic(`${id}-monorise-dlq-alarm-topic`);
 


### PR DESCRIPTION
Forward extra SST links to the app handler Lambda so custom routes can access external resources (e.g. sst.Secret) via Resource.* at runtime.

Dev package publish for this PR: https://github.com/monorist/monorise/pull/258