### PR TITLE
fix(sst): remove duplicate ANY /core/{proxy+} route registration

### DIFF
--- a/.changeset/fix-duplicate-route-registration.md
+++ b/.changeset/fix-duplicate-route-registration.md
@@ -1,0 +1,8 @@
+---
+"@monorise/sst": patch
+"monorise": patch
+---
+
+Fix duplicate `ANY /core/{proxy+}` route registration in `MonoriseCore`
+
+Without this fix, `sst dev` fails immediately with `Component name <id>-monorise-apiRouteXxxxxx is not unique`. The previous `link` PR added a new route registration block but did not remove the existing one further down the constructor, so both ran unconditionally and produced two routes on the same path. The fix folds `args.link` into the `appHandlerLinks` array up-front and keeps a single route registration at the bottom (which already handles the optional WebSocket binding).

--- a/packages/sst/components/monorise-core.ts
+++ b/packages/sst/components/monorise-core.ts
@@ -76,17 +76,12 @@ export class MonoriseCore {
       CORE_TABLE: this.table.table.name,
       CORE_EVENT_BUS: this.bus.name,
     };
-    const appHandlerLinks: any[] = [this.table.table, this.bus, secretApiKeys];
-    this.api.route('ANY /core/{proxy+}', {
-      name: appHandlerName,
-      handler: `${dotMonorisePath}/handle.appHandler`,
-      link: [this.table.table, this.bus, secretApiKeys, ...(args?.link ?? [])],
-      environment: {
-        API_KEYS: secretApiKeys.value,
-        CORE_TABLE: this.table.table.name,
-        CORE_EVENT_BUS: this.bus.name,
-      },
-    });
+    const appHandlerLinks: any[] = [
+      this.table.table,
+      this.bus,
+      secretApiKeys,
+      ...(args?.link ?? []),
+    ];
 
     this.alarmTopic = new sst.aws.SnsTopic(`${id}-monorise-dlq-alarm-topic`);
 


### PR DESCRIPTION
## Symptom

Without this fix, any consumer of `monorise@1.1.0-dev.5` hits this on `bun dev` / `sst dev` / `sst deploy`:

```
Component name <id>-monorise-apiRouteXxxxxx is not unique.
```

The boilerplate cannot boot at all — the error fires before any user code runs.

## Root cause

[#259](https://github.com/monorist/monorise/pull/259) introduced a `link` prop on `MonoriseCoreArgs`. The implementation **added a new** `this.api.route('ANY /core/{proxy+}', ...)` block right after `appHandlerLinks` was declared, but **left the pre-existing registration further down** the constructor untouched. Both calls run unconditionally — independent of the optional WebSocket config — so SST sees two routes registered against the same path on the same `ApiGatewayV2` and refuses to resolve a unique component name.

## Relationship to #258

[#258](https://github.com/monorist/monorise/pull/258) is the **same feature, different (correct) implementation** — opened earlier by the same author. It adds the same `link` prop to `MonoriseCoreArgs`, but instead of adding a new route block it **modifies the existing single registration in place** to include `...(args?.link ?? [])` in the `link` array. One file, one-line change.

It was authored against a parent commit predating WebSocket support, so it knew nothing about the bug — there was no bug at the time. But structurally, had #258 been merged instead of #259, the duplicate would never have existed.

What I think should happen:
- This PR fixes the immediate breakage on `dev`.
- #258 can be **closed as superseded** — its goal (the `link` prop) is preserved here, and its approach informed this fix.
- The merged #259 is effectively reverted in spirit: same `link` prop semantics, no second route registration.

## Fix

- Fold `...(args?.link ?? [])` into the `appHandlerLinks` array initializer.
- Delete the duplicate `this.api.route(...)` block #259 added.

The surviving registration at the bottom of the constructor already does the right thing: it uses `appHandlerLinks` (now containing `args.link`) and `appHandlerEnvironment`, and `appHandlerLinks.push(this.websocket)` runs conditionally above it when WebSocket is enabled. Net behaviour is identical to what #259 *intended*, minus the duplicate.

## Diff

```diff
-    const appHandlerLinks: any[] = [this.table.table, this.bus, secretApiKeys];
-    this.api.route('ANY /core/{proxy+}', {
-      name: appHandlerName,
-      handler: `\${dotMonorisePath}/handle.appHandler`,
-      link: [this.table.table, this.bus, secretApiKeys, ...(args?.link ?? [])],
-      environment: { ... },
-    });
+    const appHandlerLinks: any[] = [
+      this.table.table,
+      this.bus,
+      secretApiKeys,
+      ...(args?.link ?? []),
+    ];
```

(The remaining `this.api.route(...)` further down the file is unchanged and now does the work.)

## Test plan

- [x] Verified compiled `dist/sst/index.js` contains exactly one `ANY /core/{proxy+}` registration after rebuild.
- [x] Consumed locally via `npm pack` + tarball install in a downstream SST v4 boilerplate; `sst dev` no longer errors on the unique-component check (gets through to the AWS API call).
- [ ] Deploy without `args.link` — verify existing behaviour unchanged.
- [ ] Deploy with `args.link: [someSecret]` — verify the linked secret is accessible via `Resource.*` in the app handler.
- [ ] Deploy with `webSocket: { enabled: true }` — verify `WEBSOCKET_URL` env and link still propagate.

## Changeset

`patch` for \`monorise\` and \`@monorise/sst\` — restores intended behaviour from #259 with no API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)