### PR TITLE
fix(react): make useEntities content-aware so in-place edits refresh

### DIFF
--- a/.changeset/use-entities-content-aware.md
+++ b/.changeset/use-entities-content-aware.md
@@ -1,0 +1,6 @@
+---
+"@monorise/react": patch
+"monorise": patch
+---
+
+Fix `useEntities` so that content-only edits propagate to the local `entities` snapshot. Previously the effect only called `setEntities` when `dataMap.size !== entities?.length`, so an edit that mutated an entity in place (same id, new field values) was silently ignored and the consumer kept rendering stale data until a full reload. The comparison now also walks `dataMap` and falls back to a JSON content compare, matching the existing behavior of `useMutuals`.

--- a/packages/react/actions/core.action.ts
+++ b/packages/react/actions/core.action.ts
@@ -1498,11 +1498,24 @@ const initCoreActions = (
     }, [entityType, query]);
 
     useEffect(() => {
-      if (!query && dataMap.size !== entities?.length) {
-        setIsSearching(false);
-        setEntities(
-          Array.from(dataMap.values()).sort(byEntityId) as CreatedEntity<T>[],
-        );
+      if (!query) {
+        const dataMapArray = Array.from(dataMap.values()).sort(
+          byEntityId,
+        ) as CreatedEntity<T>[];
+        // Compare size AND content so that edits which keep the same set of
+        // entityIds but mutate their data (e.g. editEntity) still propagate
+        // to the local `entities` snapshot. Matches the comparison already
+        // used in `useMutuals`.
+        if (
+          dataMap.size !== entities?.length ||
+          dataMapArray.some(
+            (item, index) =>
+              JSON.stringify(item) !== JSON.stringify(entities?.[index]),
+          )
+        ) {
+          setIsSearching(false);
+          setEntities(dataMapArray);
+        }
       }
 
       if (query) {
@@ -1511,6 +1524,7 @@ const initCoreActions = (
     }, [
       dataMap,
       dataMap.size,
+      entities,
       entities?.length,
       query,
       searchResults,


### PR DESCRIPTION
## TL;DR When i try to edit an item via modal in a listing page, the listing page will not show its latest state immediately after editing.

<img width="1586" height="1328" alt="image" src="https://github.com/user-attachments/assets/8332a94b-fed0-4947-b848-a4f6fd6d4749" />

## Summary

Fix `useEntities` so that **content-only edits** propagate to the local `entities` snapshot without a page reload.

## The bug

`useEntities`'s sync effect previously gated `setEntities` on `dataMap.size !== entities?.length`:

```ts
useEffect(() => {
  if (!query && dataMap.size !== entities?.length) {
    setEntities(Array.from(dataMap.values()).sort(byEntityId));
  }
  // …
}, [dataMap, dataMap.size, entities?.length, query, searchResults, searchResults?.length]);
```

This means that whenever `editEntity` (or any other store update) mutates an entity **in place** — same `entityId`, new field values — the size check passes, the `setEntities` branch is skipped, and the consumer keeps rendering the stale array until a hard reload.

Concretely: in my consumer app, editing a person's job title via `editEntity` correctly updated DynamoDB and the local zustand store, but the `useEntities`-backed table cell stayed stale until I refreshed the page.

## The fix

Walk `dataMap` and fall back to a JSON content compare when sizes match — the same shape `useMutuals` already uses today (see `useMutuals` effect a few hundred lines below in the same file):

```ts
useEffect(() => {
  const dataMapArray = Array.from(dataMap.values());
  if (
    dataMap.size !== mutuals?.length ||
    dataMapArray.some(
      (item, index) => JSON.stringify(item) !== JSON.stringify(mutuals[index]),
    )
  ) {
    setMutuals(dataMapArray);
  }
}, [dataMap, dataMap.size, mutuals?.length]);
```

So this PR is really just **bringing `useEntities` in line with the canonical pattern already established in `useMutuals`**, not introducing a new approach. The two hooks should compare the same way.

`entities` is also added to the effect deps so the comparison reads the latest snapshot.

## Why not just `entities` reference compare?

A reference check is what we already had implicitly (via the size-only short-circuit) and it's what produced the bug — immer produces a new wrapper / new `dataMap` ref on commit, but the consumer-visible `entities` array stays the previous snapshot until we call `setEntities`. Matching `useMutuals`'s JSON walk is the smallest change that preserves intent (skip when truly unchanged) while also catching in-place edits.

## Cost

- `JSON.stringify` per entity per render when `dataMap` changes. Already accepted by `useMutuals`, so we're not introducing new overhead — just applying it consistently. For lists past a few thousand entries either hook would want a smarter comparator, but that's an orthogonal change.

## Test plan

- [x] Verified in a consumer app: editing an entity's field via `editEntity` now causes the corresponding row/cell to update without a page reload.
- [x] `useMutuals` flows (which already had this comparison) are unaffected.
- [x] `useEntities` create / delete paths still trigger via the existing size-change path.

## Notes

- Changeset added: `@monorise/react` patch + `monorise` patch.
- Targets `dev` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)