### PR TITLE
fix(react): preserve correct entity data on flipped mutual cache side

### DIFF
--- a/.changeset/flip-mutual-restores-flipped-side-data.md
+++ b/.changeset/flip-mutual-restores-flipped-side-data.md
@@ -1,0 +1,6 @@
+---
+"@monorise/react": patch
+"monorise": patch
+---
+
+Fix `flipMutual` so the flipped-side mutual cache entry's `data` describes the correct entity. Previously the flipped record reused the original side's `data`, which made `useMutuals` on the opposite view briefly render the wrong entity's fields after `createMutual`/`editMutual`/`upsertLocalMutual`/`createLocalMutual` — until a refresh refetched that side from the server.

--- a/packages/react/actions/core.action.ts
+++ b/packages/react/actions/core.action.ts
@@ -997,9 +997,12 @@ const initCoreActions = (
             };
           }
 
+          const byEntityData =
+            state.entity[mutual.byEntityType]?.dataMap.get(mutual.byEntityId)
+              ?.data ?? {};
           state.mutual[side].dataMap = new Map(state.mutual[side]?.dataMap).set(
             mutual.byEntityId,
-            flipMutual(mutual),
+            flipMutual(mutual, byEntityData),
           );
         }),
         undefined,
@@ -1052,9 +1055,12 @@ const initCoreActions = (
           };
         }
 
+        const byEntityData =
+          state.entity[mutual.byEntityType]?.dataMap.get(mutual.byEntityId)
+            ?.data ?? {};
         state.mutual[side].dataMap = new Map(state.mutual[side]?.dataMap).set(
           mutual.byEntityId,
-          flipMutual(mutual),
+          flipMutual(mutual, byEntityData),
         );
       }),
       undefined,
@@ -1116,9 +1122,12 @@ const initCoreActions = (
           };
         }
 
+        const byEntityData =
+          state.entity[mutual.byEntityType]?.dataMap.get(mutual.byEntityId)
+            ?.data ?? {};
         state.mutual[side].dataMap = new Map(state.mutual[side]?.dataMap).set(
           byEntityId,
-          flipMutual(mutual),
+          flipMutual(mutual, byEntityData),
         );
       }),
       undefined,
@@ -1170,9 +1179,12 @@ const initCoreActions = (
             };
           }
 
+          const byEntityData =
+            state.entity[mutual.byEntityType]?.dataMap.get(mutual.byEntityId)
+              ?.data ?? {};
           state.mutual[side].dataMap = new Map(state.mutual[side]?.dataMap).set(
             mutual.byEntityId,
-            flipMutual(mutual),
+            flipMutual(mutual, byEntityData),
           );
         }),
         undefined,

--- a/packages/react/lib/entity.ts
+++ b/packages/react/lib/entity.ts
@@ -37,13 +37,27 @@ export const constructMutual = <B extends Entity, T extends Entity>(
   };
 };
 
-export const flipMutual = (mutual: Mutual): Mutual => {
+// A mutual is stored under two cache keys — one per direction. When we mirror
+// a record from the `BY/byId/OTHER` side to the `OTHER/otherId/BY` side, the
+// `data` field has to be substituted: on the original side `data` describes
+// the OTHER entity (the one at `entityType/entityId`); after flipping, the
+// new `entityType/entityId` points to what *was* the BY entity, so `data`
+// must now describe that entity. Callers look up the BY entity from the
+// entity store and pass its data in here. `{}` is an accepted fallback for
+// the case where the BY entity hasn't been hydrated locally yet — better to
+// surface an empty record than to leak the OTHER entity's fields onto a
+// record that no longer describes it.
+export const flipMutual = (
+  mutual: Mutual,
+  byEntityData: Record<string, unknown>,
+): Mutual => {
   return {
     ...mutual,
     entityId: mutual.byEntityId,
     entityType: mutual.byEntityType,
     byEntityId: mutual.entityId,
     byEntityType: mutual.entityType,
+    data: byEntityData as Mutual['data'],
   };
 };
 


### PR DESCRIPTION
# TLDR - when you edit `mutual/A/<aId>/B/<bId>`, the state for `mutual/B/<bId>/A/<aId>` is still having old/stale state

## Problem

A mutual is stored under **two cache keys** (one per direction). When mirroring a record to the flipped side, `flipMutual` swapped the entity IDs/types — but left `data` untouched.

By convention `mutual.data` describes the entity at `entityType/entityId` (the "far end"). After the flip, that pointer changes, so the flipped record ends up describing the wrong entity.

User-visible symptom in consuming apps: after saving an allocation (or any mutual) from one view, navigating to the opposite view briefly shows the wrong entity's fields on the new record — e.g. a person's name where a project's name should be — until a hard refresh refetches that side from the server.

Affects `createMutual`, `editMutual`, `upsertLocalMutual`, and `createLocalMutual`.

## Solution

`flipMutual` now takes a required `byEntityData` parameter and uses it as the flipped record's `data`. The four call sites in `core.action.ts` look the BY entity up from the local entity store:

```ts
const byEntityData =
  state.entity[mutual.byEntityType]?.dataMap.get(mutual.byEntityId)?.data ?? {};
flipMutual(mutual, byEntityData);
```

Fallback to `{}` when the BY entity isn't hydrated locally yet — strictly better than leaking the other side's fields. Consumers reading `m.data.name ?? 'Unknown'` will see the fallback for one render until `useEntities`/`useEntity` populates the store, which is the same degraded mode as any cold-cache view.

## Why this convention

Three other places in the codebase already treat `data` as "the far-end entity's payload":
- Server response shape for `/core/mutual/BY/OTHER/byId`
- Entity-create auto-populate (`core.action.ts:511`)
- Every `useMutuals` consumer I've audited (`m.data.name` is read as the far-end entity's name)

This change aligns `flipMutual` with that convention. No public API changes.

## Test plan

- [ ] Save a mutual from one direction, immediately read it from the opposite direction via `useMutuals` — `m.data` describes the correct entity.
- [ ] Repeat with the BY entity *not* in the local entity store — `m.data` is `{}` and consumers fall back to their defaults gracefully.
- [ ] Existing `useMutuals` flows on the originating side are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)