### PR TITLE
fix(react): backport useEntities + flipMutual fixes to main

### DIFF
--- a/.changeset/flip-mutual-restores-flipped-side-data.md
+++ b/.changeset/flip-mutual-restores-flipped-side-data.md
@@ -1,0 +1,6 @@
+---
+"@monorise/react": patch
+"monorise": patch
+---
+
+Fix `flipMutual` so the flipped-side mutual cache entry's `data` describes the correct entity. Previously the flipped record reused the original side's `data`, which made `useMutuals` on the opposite view briefly render the wrong entity's fields after `createMutual`/`editMutual`/`upsertLocalMutual`/`createLocalMutual` — until a refresh refetched that side from the server.

--- a/.changeset/use-entities-content-aware.md
+++ b/.changeset/use-entities-content-aware.md
@@ -1,0 +1,6 @@
+---
+"@monorise/react": patch
+"monorise": patch
+---
+
+Fix `useEntities` so that content-only edits propagate to the local `entities` snapshot. Previously the effect only called `setEntities` when `dataMap.size !== entities?.length`, so an edit that mutated an entity in place (same id, new field values) was silently ignored and the consumer kept rendering stale data until a full reload. The comparison now also walks `dataMap` and falls back to a JSON content compare, matching the existing behavior of `useMutuals`.

--- a/packages/react/actions/core.action.ts
+++ b/packages/react/actions/core.action.ts
@@ -1498,11 +1498,24 @@ const initCoreActions = (
     }, [entityType, query]);
 
     useEffect(() => {
-      if (!query && dataMap.size !== entities?.length) {
-        setIsSearching(false);
-        setEntities(
-          Array.from(dataMap.values()).sort(byEntityId) as CreatedEntity<T>[],
-        );
+      if (!query) {
+        const dataMapArray = Array.from(dataMap.values()).sort(
+          byEntityId,
+        ) as CreatedEntity<T>[];
+        // Compare size AND content so that edits which keep the same set of
+        // entityIds but mutate their data (e.g. editEntity) still propagate
+        // to the local `entities` snapshot. Matches the comparison already
+        // used in `useMutuals`.
+        if (
+          dataMap.size !== entities?.length ||
+          dataMapArray.some(
+            (item, index) =>
+              JSON.stringify(item) !== JSON.stringify(entities?.[index]),
+          )
+        ) {
+          setIsSearching(false);
+          setEntities(dataMapArray);
+        }
       }
 
       if (query) {
@@ -1511,6 +1524,7 @@ const initCoreActions = (
     }, [
       dataMap,
       dataMap.size,
+      entities,
       entities?.length,
       query,
       searchResults,

--- a/packages/react/actions/core.action.ts
+++ b/packages/react/actions/core.action.ts
@@ -997,9 +997,12 @@ const initCoreActions = (
             };
           }
 
+          const byEntityData =
+            state.entity[mutual.byEntityType]?.dataMap.get(mutual.byEntityId)
+              ?.data ?? {};
           state.mutual[side].dataMap = new Map(state.mutual[side]?.dataMap).set(
             mutual.byEntityId,
-            flipMutual(mutual),
+            flipMutual(mutual, byEntityData),
           );
         }),
         undefined,
@@ -1052,9 +1055,12 @@ const initCoreActions = (
           };
         }
 
+        const byEntityData =
+          state.entity[mutual.byEntityType]?.dataMap.get(mutual.byEntityId)
+            ?.data ?? {};
         state.mutual[side].dataMap = new Map(state.mutual[side]?.dataMap).set(
           mutual.byEntityId,
-          flipMutual(mutual),
+          flipMutual(mutual, byEntityData),
         );
       }),
       undefined,
@@ -1116,9 +1122,12 @@ const initCoreActions = (
           };
         }
 
+        const byEntityData =
+          state.entity[mutual.byEntityType]?.dataMap.get(mutual.byEntityId)
+            ?.data ?? {};
         state.mutual[side].dataMap = new Map(state.mutual[side]?.dataMap).set(
           byEntityId,
-          flipMutual(mutual),
+          flipMutual(mutual, byEntityData),
         );
       }),
       undefined,
@@ -1170,9 +1179,12 @@ const initCoreActions = (
             };
           }
 
+          const byEntityData =
+            state.entity[mutual.byEntityType]?.dataMap.get(mutual.byEntityId)
+              ?.data ?? {};
           state.mutual[side].dataMap = new Map(state.mutual[side]?.dataMap).set(
             mutual.byEntityId,
-            flipMutual(mutual),
+            flipMutual(mutual, byEntityData),
           );
         }),
         undefined,

--- a/packages/react/lib/entity.ts
+++ b/packages/react/lib/entity.ts
@@ -37,13 +37,27 @@ export const constructMutual = <B extends Entity, T extends Entity>(
   };
 };
 
-export const flipMutual = (mutual: Mutual): Mutual => {
+// A mutual is stored under two cache keys — one per direction. When we mirror
+// a record from the `BY/byId/OTHER` side to the `OTHER/otherId/BY` side, the
+// `data` field has to be substituted: on the original side `data` describes
+// the OTHER entity (the one at `entityType/entityId`); after flipping, the
+// new `entityType/entityId` points to what *was* the BY entity, so `data`
+// must now describe that entity. Callers look up the BY entity from the
+// entity store and pass its data in here. `{}` is an accepted fallback for
+// the case where the BY entity hasn't been hydrated locally yet — better to
+// surface an empty record than to leak the OTHER entity's fields onto a
+// record that no longer describes it.
+export const flipMutual = (
+  mutual: Mutual,
+  byEntityData: Record<string, unknown>,
+): Mutual => {
   return {
     ...mutual,
     entityId: mutual.byEntityId,
     entityType: mutual.byEntityType,
     byEntityId: mutual.entityId,
     byEntityType: mutual.entityType,
+    data: byEntityData as Mutual['data'],
   };
 };
 


### PR DESCRIPTION
### Follow up from our previous discussion, merging back changes to `dev` earlier to `main` branch now.
 
## Summary

Backports two react-package bugfixes from `dev` (already merged via #264 and #266) onto `main`, since `dev` won't be merged back into `main`.

- **#264** `fix(react): make useEntities content-aware so in-place edits refresh` — `useEntities` only updated state when `dataMap.size` changed, so edits that kept the same entity IDs but mutated their data were silently dropped. Now matches `useMutuals`' content-aware comparison.
- **#266** `fix(react): preserve correct entity data on flipped mutual cache side` — `flipMutual` swapped entity IDs/types when mirroring a mutual to its opposite cache key but left `data` untouched, leaving the flipped record describing the wrong entity. `flipMutual` now takes a required `byEntityData` parameter, and the four call sites in `core.action.ts` look it up from `state.entity[byEntityType]?.dataMap.get(byEntityId)?.data`.

Both changesets are included.

## Test plan

- [ ] CI green
- [ ] No conflicts vs. existing react package on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)