### PR TITLE
ci: publish to npm via OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,10 @@ jobs:
   release:
     name: Version Bump & Create Release PR
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # mint the OIDC token for npm Trusted Publishing
+      contents: write # changesets: push version-bump commit + tags
+      pull-requests: write # changesets: open/update the release PR
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -21,6 +25,10 @@ jobs:
         with:
           node-version: 22
           cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm for OIDC Trusted Publishing (needs >= 11.5.1)
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: |
@@ -35,4 +43,3 @@ jobs:
           version: npm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Why
Token publishes are failing — npm requires 2FA on the publish token, so `changeset publish` dies with `E404` (`monorise`, `@monorise/react`) even after swapping the token. [Trusted Publishing (OIDC)](https://docs.npmjs.com/trusted-publishers) removes the stored secret entirely: the runner mints a short-lived credential per run, and publishes get provenance attestations for free.

## Workflow changes
- **`permissions: id-token: write`** — required for the runner to request the OIDC token npm exchanges for a publish credential. Added `contents: write` + `pull-requests: write` explicitly (changesets pushes version bumps/tags and opens the release PR — previously implicit via default `GITHUB_TOKEN` perms).
- **`registry-url` on setup-node** — writes the base `.npmrc` pointing at npmjs.org; with no token present npm falls through to OIDC.
- **`npm install -g npm@latest`** — OIDC Trusted Publishing needs **npm >= 11.5.1**; Node 22 ships npm 10.x, so without this the publish silently ignores OIDC and fails again.
- **Removed `NPM_TOKEN`** — so `changesets/action` doesn't write a token-based `.npmrc` that would take precedence over OIDC.

## Required npm-side setup (before merge takes effect)
Configure a **Trusted Publisher per package** on npmjs.com (Settings → Publishing access):
- Publisher: **GitHub Actions**, Org: `monorist`, Repo: `monorise`, Workflow filename: `release.yaml`, Environment: *(blank)*, Allow: **npm publish**
- Do this for `monorise` and `@monorise/react` at minimum; ideally also `@monorise/base`, `@monorise/core`, `@monorise/cli`, `@monorise/proxy`, `@monorise/sst` for their next releases.

## Notes
- Provenance requires a public repo (the `id-token` perm covers it). If the repo is private, add `NPM_CONFIG_PROVENANCE: false`.
- If `changesets/action@v1` complains about missing npm auth on the first OIDC run, bump it to the latest tag.