### PR TITLE
DEV ci: publish to npm via OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,10 @@ jobs:
   release:
     name: Version Bump & Create Release PR
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # mint the OIDC token for npm Trusted Publishing
+      contents: write # changesets: push version-bump commit + tags
+      pull-requests: write # changesets: open/update the release PR
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -21,6 +25,10 @@ jobs:
         with:
           node-version: 22
           cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm for OIDC Trusted Publishing (needs >= 11.5.1)
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: |
@@ -35,4 +43,3 @@ jobs:
           version: npm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Applies the OIDC Trusted Publishing workflow change (same as #275, which targets `main`) to **`dev`**.

## Why on dev specifically
The failed release run was on `dev` (SHA `a6d7c552`), and the unpublished versions — `monorise@1.1.0-dev.10` and `@monorise/react@5.0.0-dev.6` — are bumped/committed on `dev`. GitHub Actions runs the workflow file *from the branch being pushed*, so the `dev` release run reads `dev`'s `release.yaml`. The fix on `main` alone won't republish the dev versions — `dev` needs it too.

## Changes (identical to #275)
- `permissions: id-token: write` (+ `contents`/`pull-requests` for changesets)
- `registry-url` on setup-node
- `npm install -g npm@latest` (OIDC needs npm >= 11.5.1; Node 22 ships 10.x)
- Removed `NPM_TOKEN`

## Effect on merge
Merging this is a push to `dev` → fresh Release run with the new workflow → `changeset publish` publishes `dev.10`/`dev.6` via OIDC (changesets already consumed, versions already committed — no new changeset needed).

Prereq: Trusted Publishers configured on npm for `monorise` + `@monorise/react` (org `monorist`, repo `monorise`, workflow `release.yaml`, allow `npm publish`).