### PR TITLE
DEV chore: add repository field to published packages (npm provenance)

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@monorise/base",
   "version": "4.1.0-dev.3",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/monorist/monorise.git",
+    "directory": "packages/base"
+  },
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@monorise/cli",
   "version": "4.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/monorist/monorise.git",
+    "directory": "packages/cli"
+  },
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@monorise/core",
   "version": "5.0.0-dev.4",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/monorist/monorise.git",
+    "directory": "packages/core"
+  },
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/monorise/package.json
+++ b/packages/monorise/package.json
@@ -1,6 +1,11 @@
 {
   "name": "monorise",
   "version": "1.1.0-dev.10",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/monorist/monorise.git",
+    "directory": "packages/monorise"
+  },
   "description": "Monorise - A unified package for all Monorise functionality",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@monorise/proxy",
   "version": "3.1.0-dev.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/monorist/monorise.git",
+    "directory": "packages/proxy"
+  },
   "description": "Proxy helpers for monorise - used in Next.js API routes and similar proxy layers",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@monorise/react",
   "version": "5.0.0-dev.6",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/monorist/monorise.git",
+    "directory": "packages/react"
+  },
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sst/package.json
+++ b/packages/sst/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@monorise/sst",
   "version": "4.1.0-dev.4",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/monorist/monorise.git",
+    "directory": "packages/sst"
+  },
   "description": "",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Follow-up to the OIDC change (#276). OIDC publishing auto-enables **provenance**, which validates each package's `package.json` `repository.url` against the source repo. All published packages were missing `repository`, so the post-OIDC release run failed with:

```
E422 - Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "", expected to match "https://github.com/monorist/monorise"
```

Adds `repository` (git URL + monorepo `directory`) to all 7 published packages. Merging this to `dev` triggers a fresh release run that should publish `monorise@1.1.0-dev.10` + `@monorise/react@5.0.0-dev.6` with valid provenance.