### PR TITLE
chore: add repository field to published packages (npm provenance)

### DIFF
--- a/packages/base/package.json
+++ b/packages/base/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@monorise/base",
   "version": "4.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/monorist/monorise.git",
+    "directory": "packages/base"
+  },
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@monorise/cli",
   "version": "4.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/monorist/monorise.git",
+    "directory": "packages/cli"
+  },
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@monorise/core",
   "version": "4.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/monorist/monorise.git",
+    "directory": "packages/core"
+  },
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/monorise/package.json
+++ b/packages/monorise/package.json
@@ -1,6 +1,11 @@
 {
   "name": "monorise",
   "version": "1.0.1",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/monorist/monorise.git",
+    "directory": "packages/monorise"
+  },
   "description": "Monorise - A unified package for all Monorise functionality",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@monorise/react",
   "version": "4.0.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/monorist/monorise.git",
+    "directory": "packages/react"
+  },
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/sst/package.json
+++ b/packages/sst/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@monorise/sst",
   "version": "4.0.2",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/monorist/monorise.git",
+    "directory": "packages/sst"
+  },
   "description": "",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Follow-up to the OIDC change (#275). OIDC publishing auto-enables **provenance**, which validates each package's `package.json` `repository.url` against the source repo. Published packages were missing `repository`, causing `E422` (`repository.url` is `""`) on publish.

Adds `repository` (git URL + monorepo `directory`) to all published packages on `main` (6 — `proxy` is dev-only, not yet on `main`).