### PR TITLE
Add global CloudWatch log retention for Monorise core

### DIFF
--- a/.changeset/bright-wolves-listen.md
+++ b/.changeset/bright-wolves-listen.md
@@ -1,0 +1,6 @@
+---
+'@monorise/sst': minor
+'monorise': minor
+---
+
+Add a `cloudwatchLogRetention` option to configure log retention for Monorise core Lambda functions.

--- a/packages/sst/components/monorise-core.ts
+++ b/packages/sst/components/monorise-core.ts
@@ -4,12 +4,38 @@ import { createFunctionWidgets } from './dashboard';
 import { QFunction } from './q-function';
 import { SingleTable } from './single-table';
 
+type CloudWatchLogRetention =
+  | '1 day'
+  | '3 days'
+  | '5 days'
+  | '1 week'
+  | '2 weeks'
+  | '1 month'
+  | '2 months'
+  | '3 months'
+  | '4 months'
+  | '5 months'
+  | '6 months'
+  | '1 year'
+  | '13 months'
+  | '18 months'
+  | '2 years'
+  | '3 years'
+  | '5 years'
+  | '6 years'
+  | '7 years'
+  | '8 years'
+  | '9 years'
+  | '10 years'
+  | 'forever';
+
 type MonoriseCoreArgs = {
   fromTableName?: $util.Input<string>;
   slackWebhook?: string;
   allowHeaders?: string[];
   allowOrigins?: string[];
   configRoot?: string;
+  cloudwatchLogRetention?: $util.Input<CloudWatchLogRetention>;
 };
 
 export class MonoriseCore {
@@ -25,6 +51,9 @@ export class MonoriseCore {
       ? `--config-root ${args.configRoot}`
       : '';
     const dotMonorisePath = path.join(args?.configRoot ?? '', '.monorise');
+    const logging = args?.cloudwatchLogRetention
+      ? { retention: args.cloudwatchLogRetention }
+      : undefined;
 
     new sst.x.DevCommand('Monorise', {
       dev: {
@@ -53,6 +82,7 @@ export class MonoriseCore {
       runtime,
       configRoot: args?.configRoot,
       fromTableName: args?.fromTableName,
+      logging,
     });
 
     const secretApiKeys = new sst.Secret('API_KEYS', '["secret1", "secret2"]');
@@ -67,6 +97,7 @@ export class MonoriseCore {
         CORE_TABLE: this.table.table.name,
         CORE_EVENT_BUS: this.bus.name,
       },
+      logging,
     });
 
     this.alarmTopic = new sst.aws.SnsTopic(`${id}-monorise-dlq-alarm-topic`);
@@ -93,6 +124,7 @@ export class MonoriseCore {
       runtime,
       environment,
       link: [this.table.table, this.bus],
+      logging,
     });
 
     const tagProcessor = new QFunction('tag', {
@@ -105,6 +137,7 @@ export class MonoriseCore {
       runtime,
       environment,
       link: [this.table.table],
+      logging,
     });
 
     const treeProcessor = new QFunction('tree', {
@@ -117,6 +150,7 @@ export class MonoriseCore {
       runtime,
       environment,
       link: [this.table.table],
+      logging,
     });
 
     this.bus.subscribeQueue(`${id}-mutual-queue-rule`, mutualProcessor.queue, {

--- a/packages/sst/components/single-table.ts
+++ b/packages/sst/components/single-table.ts
@@ -6,6 +6,7 @@ import {
 
 type SingleTableArgs = {
   runtime?: sst.aws.FunctionArgs['runtime'];
+  logging?: sst.aws.FunctionArgs['logging'];
   configRoot?: string;
   /**
    * Name of an existing DynamoDB table to use instead of creating a new one.
@@ -83,6 +84,7 @@ export class SingleTable {
         timeout: '60 seconds',
         memory: '512 MB',
         runtime: args?.runtime,
+        logging: args?.logging,
         environment,
         link: [this.table, this.dlq],
       },

--- a/www/docs/getting-started.md
+++ b/www/docs/getting-started.md
@@ -236,6 +236,7 @@ new monorise.module.Core('core', {
   allowHeaders: ['x-custom-header'],     // Additional CORS headers
   slackWebhook: 'https://hooks...',     // Slack alerts for processor errors
   configRoot: './services/api',          // Custom config root path
+  cloudwatchLogRetention: '1 week',      // Lambda log retention period
 });
 ```
 

--- a/www/docs/sst.md
+++ b/www/docs/sst.md
@@ -29,6 +29,7 @@ const { monorise } = await import('monorise/sst');
 
 const { bus, api, table, alarmTopic } = new monorise.module.Core('core', {
   allowOrigins: ['http://localhost:3000'],
+  cloudwatchLogRetention: '1 week',
 });
 ```
 
@@ -45,6 +46,9 @@ new MonoriseCore(id: string, args?: MonoriseCoreArgs)
 | `allowHeaders` | `string[]` | `['Content-Type', 'Authorization']` | Additional CORS headers |
 | `slackWebhook` | `string` | — | Slack webhook URL for DLQ alerts |
 | `configRoot` | `string` | — | Custom root path for monorise config |
+| `cloudwatchLogRetention` | `sst.aws.FunctionArgs['logging']['retention']` | `'1 month'` | CloudWatch log retention period for Monorise-owned Lambda functions |
+
+`cloudwatchLogRetention` is passed to SST's Lambda logging configuration for the API handler, replication processor, and built-in event processors. It accepts SST's supported retention values, for example `'1 day'`, `'1 week'`, `'1 month'`, `'1 year'`, or `'forever'`.
 
 ### Exposed resources
 


### PR DESCRIPTION
## Summary
- Add `cloudwatchLogRetention` to `MonoriseCore`
- Apply the retention setting to core Lambda log groups
- Thread logging config into the table replicator function
- Document the option in the SST SDK and getting-started docs
- Add minor changeset entries for `@monorise/sst` and `monorise`

## Testing
- `npm -w @monorise/sst run build`
- `rtk tsc --project packages/sst/tsconfig.json --emitDeclarationOnly --outDir packages/sst/dist`
- `npm -w @monorise/www run docs:build`