### PR TITLE
feat(sst): make CloudWatch dashboard toggleable

### DIFF
--- a/.changeset/tidy-geckos-shine.md
+++ b/.changeset/tidy-geckos-shine.md
@@ -1,0 +1,5 @@
+---
+'@monorise/sst': minor
+---
+
+Add a `cloudwatchDashboard` option to make the built-in CloudWatch dashboard toggleable. Set `cloudwatchDashboard: { enabled: false }` to skip creating the dashboard — useful for test and personal stages where the dashboard would only add cost. Defaults to enabled, so existing stages are unaffected. Note: disabling it on a stage where the dashboard already exists will destroy the dashboard on the next deploy.

--- a/.changeset/tidy-geckos-shine.md
+++ b/.changeset/tidy-geckos-shine.md
@@ -1,5 +1,6 @@
 ---
 '@monorise/sst': minor
+'monorise': minor
 ---
 
 Add a `cloudwatchDashboard` option to make the built-in CloudWatch dashboard toggleable. Set `cloudwatchDashboard: { enabled: false }` to skip creating the dashboard — useful for test and personal stages where the dashboard would only add cost. Defaults to enabled, so existing stages are unaffected. Note: disabling it on a stage where the dashboard already exists will destroy the dashboard on the next deploy.

--- a/packages/sst/components/monorise-core.ts
+++ b/packages/sst/components/monorise-core.ts
@@ -10,6 +10,9 @@ type MonoriseCoreArgs = {
   allowHeaders?: string[];
   allowOrigins?: string[];
   configRoot?: string;
+  cloudwatchDashboard?: {
+    enabled?: boolean;
+  };
 };
 
 export class MonoriseCore {
@@ -152,69 +155,71 @@ export class MonoriseCore {
     /**
      * CloudWatch Dashboard
      */
-    new aws.cloudwatch.Dashboard(`${id}-monorise-dashboard`, {
-      dashboardName: `${$app.stage}-${$app.name}-${id}-monorise`,
-      dashboardBody: $resolve([
-        aws.getRegionOutput().name,
-        this.table.table.name,
-        mutualProcessor.dlq.nodes.queue.name,
-        tagProcessor.dlq.nodes.queue.name,
-        treeProcessor.dlq.nodes.queue.name,
-        this.table.dlq.nodes.queue.name,
-      ]).apply(
-        ([region, tableName, mutualDlq, tagDlq, treeDlq, replicatorDlq]) => {
-          const dynamoDbUrl = `https://${region}.console.aws.amazon.com/dynamodbv2/home?region=${region}#table?name=${tableName}&tab=monitoring`;
+    if (args?.cloudwatchDashboard?.enabled !== false) {
+      new aws.cloudwatch.Dashboard(`${id}-monorise-dashboard`, {
+        dashboardName: `${$app.stage}-${$app.name}-${id}-monorise`,
+        dashboardBody: $resolve([
+          aws.getRegionOutput().name,
+          this.table.table.name,
+          mutualProcessor.dlq.nodes.queue.name,
+          tagProcessor.dlq.nodes.queue.name,
+          treeProcessor.dlq.nodes.queue.name,
+          this.table.dlq.nodes.queue.name,
+        ]).apply(
+          ([region, tableName, mutualDlq, tagDlq, treeDlq, replicatorDlq]) => {
+            const dynamoDbUrl = `https://${region}.console.aws.amazon.com/dynamodbv2/home?region=${region}#table?name=${tableName}&tab=monitoring`;
 
-          return JSON.stringify({
-            widgets: [
-              {
-                type: 'text',
-                x: 0,
-                y: 0,
-                width: 24,
-                height: 2,
-                properties: {
-                  markdown: `### Related Resources\n[View DynamoDB Table Metrics](${dynamoDbUrl})`,
+            return JSON.stringify({
+              widgets: [
+                {
+                  type: 'text',
+                  x: 0,
+                  y: 0,
+                  width: 24,
+                  height: 2,
+                  properties: {
+                    markdown: `### Related Resources\n[View DynamoDB Table Metrics](${dynamoDbUrl})`,
+                  },
                 },
-              },
-              ...createFunctionWidgets(
-                'API Handler',
-                appHandlerName,
-                2,
-                region,
-              ),
-              ...createFunctionWidgets(
-                'Replicator',
-                this.table.replicatorFunctionName,
-                9,
-                region,
-                replicatorDlq,
-              ),
-              ...createFunctionWidgets(
-                'Mutual Processor',
-                mutualProcessorName,
-                16,
-                region,
-                mutualDlq,
-              ),
-              ...createFunctionWidgets(
-                'Tag Processor',
-                tagProcessorName,
-                23,
-                region,
-                tagDlq,
-              ),
-              ...createFunctionWidgets(
-                'Tree Processor',
-                treeProcessorName,
-                30,
-                region,
-                treeDlq,
-              ),
-            ],
-          });
-        },
-      ),
-    });
+                ...createFunctionWidgets(
+                  'API Handler',
+                  appHandlerName,
+                  2,
+                  region,
+                ),
+                ...createFunctionWidgets(
+                  'Replicator',
+                  this.table.replicatorFunctionName,
+                  9,
+                  region,
+                  replicatorDlq,
+                ),
+                ...createFunctionWidgets(
+                  'Mutual Processor',
+                  mutualProcessorName,
+                  16,
+                  region,
+                  mutualDlq,
+                ),
+                ...createFunctionWidgets(
+                  'Tag Processor',
+                  tagProcessorName,
+                  23,
+                  region,
+                  tagDlq,
+                ),
+                ...createFunctionWidgets(
+                  'Tree Processor',
+                  treeProcessorName,
+                  30,
+                  region,
+                  treeDlq,
+                ),
+              ],
+            });
+          },
+        ),
+      });
+    }
   }
 }

--- a/www/docs/getting-started.md
+++ b/www/docs/getting-started.md
@@ -232,9 +232,9 @@ export default $config({
 
 ```ts
 new monorise.module.Core('core', {
-  allowOrigins: ['https://myapp.com'],  // CORS origins
+  allowOrigins: ['https://myapp.com'],   // CORS origins
   allowHeaders: ['x-custom-header'],     // Additional CORS headers
-  slackWebhook: 'https://hooks...',     // Slack alerts for processor errors
+  slackWebhook: 'https://hooks...',      // Slack alerts for processor errors
   configRoot: './services/api',          // Custom config root path
   cloudwatchDashboard: { enabled: $app.stage === 'production' },  // Dashboard only on prod
 });

--- a/www/docs/getting-started.md
+++ b/www/docs/getting-started.md
@@ -236,6 +236,7 @@ new monorise.module.Core('core', {
   allowHeaders: ['x-custom-header'],     // Additional CORS headers
   slackWebhook: 'https://hooks...',     // Slack alerts for processor errors
   configRoot: './services/api',          // Custom config root path
+  cloudwatchDashboard: { enabled: $app.stage === 'production' },  // Dashboard only on prod
 });
 ```
 

--- a/www/docs/sst.md
+++ b/www/docs/sst.md
@@ -45,6 +45,17 @@ new MonoriseCore(id: string, args?: MonoriseCoreArgs)
 | `allowHeaders` | `string[]` | `['Content-Type', 'Authorization']` | Additional CORS headers |
 | `slackWebhook` | `string` | — | Slack webhook URL for DLQ alerts |
 | `configRoot` | `string` | — | Custom root path for monorise config |
+| `cloudwatchDashboard` | `{ enabled?: boolean }` | `{ enabled: true }` | Built-in CloudWatch dashboard. Disable to skip creating it |
+
+`cloudwatchDashboard` controls whether the built-in CloudWatch dashboard is created. It defaults to enabled for backward compatibility, but short-lived stages (test, personal dev) rarely need a dashboard and each one adds cost, so a common pattern is to enable it only for production:
+
+```ts
+const { bus, api, table, alarmTopic } = new monorise.module.Core('core', {
+  cloudwatchDashboard: { enabled: $app.stage === 'production' },
+});
+```
+
+Disabling it on a stage where the dashboard already exists will destroy the dashboard on the next deploy.
 
 ### Exposed resources
 
@@ -82,7 +93,7 @@ Under the hood, `MonoriseCore` creates:
 - **EventBridge bus** for publishing entity events
 - **3 QFunction processors** (mutual, tag, prejoin) — each with SQS queue, Lambda, DLQ, and CloudWatch alarm
 - **Replication processor** — DynamoDB stream subscriber that keeps denormalized data in sync
-- **CloudWatch dashboard** with metrics for all Lambda functions, DLQ depths, and a link to DynamoDB table monitoring
+- **CloudWatch dashboard** with metrics for all Lambda functions, DLQ depths, and a link to DynamoDB table monitoring (can be disabled via `cloudwatchDashboard`)
 - **SST DevCommand** — automatically runs `monorise dev` in watch mode during `sst dev`
 
 ### DynamoDB table structure


### PR DESCRIPTION
## Why

SST makes it trivial to deploy many stages (test stages, per-engineer personal stages). Each stage currently creates a CloudWatch dashboard unconditionally — past the free tier that's ~$3/dashboard/month for dashboards nobody ever opens. Only long-lived environments (notably prod) actually need one.

## What

- New `cloudwatchDashboard?: { enabled?: boolean }` option on `MonoriseCore`. Set `enabled: false` to skip creating the dashboard.
- Defaults to **enabled** — fully backward compatible, existing stages see no diff on upgrade.
- Docs updated with the recommended pattern:

```ts
new monorise.module.Core('core', {
  cloudwatchDashboard: { enabled: $app.stage === 'production' },
});
```

## Notes

- Disabling on a stage where the dashboard already exists destroys it on next deploy (intended cost saving; called out in changeset + docs).
- Object shape leaves room for future options (custom name, extra widgets) without another API change.
- Changeset: minor bump for `@monorise/sst`.
- Explored via an OpenSpec change proposal locally (artifacts not committed, per repo convention).