### PR TITLE
fix(react): keep transactional browser-safe

### DIFF
--- a/.changeset/bright-mice-hug.md
+++ b/.changeset/bright-mice-hug.md
@@ -4,3 +4,11 @@
 ---
 
 Keep the React transactional builder browser-safe.
+
+- `@monorise/react` no longer re-exports `transactional` from `@monorise/core`,
+  so browser bundles no longer pull in server-only Core code (AWS SDK, `fs`,
+  `async_hooks`). React exposes its own builder with the same wire format.
+- The unified `monorise` root no longer exports `transactional` (the name is
+  ambiguous between the Core and React copies). Use `monorise/core` on the
+  server or `monorise/react` in the browser instead. All other root exports
+  are unchanged.

--- a/.changeset/bright-mice-hug.md
+++ b/.changeset/bright-mice-hug.md
@@ -1,0 +1,6 @@
+---
+'@monorise/react': patch
+'monorise': patch
+---
+
+Keep the React transactional builder browser-safe.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "packageManager": "npm@10.9.2",
   "scripts": {
-    "build": "npm run clear-dist && turbo run build --force && npm run build:monorise",
+    "build": "npm run clear-dist && turbo run build --force",
     "build:monorise": "cd packages/monorise && npm run build",
     "changeset": "npx @changesets/cli",
     "changeset:dev-exit": "npm run changeset -- pre exit",

--- a/packages/core/helpers/transactional.ts
+++ b/packages/core/helpers/transactional.ts
@@ -7,6 +7,9 @@ import type {
   TransactionUpdateEntity,
 } from '../types/transaction';
 
+// NOTE: packages/react/helpers/transactional.ts is a browser-safe copy of
+// this builder. Both emit the same wire format for the execute-transaction
+// endpoint — keep operation shapes in sync when changing either file.
 export const transactional = {
   createEntity: <T extends EntityType>(
     entityType: T,

--- a/packages/monorise/build.js
+++ b/packages/monorise/build.js
@@ -92,8 +92,14 @@ packages.forEach((pkg) => {
   }
 });
 
-// Create a root entrypoint that exposes packages without flattening their APIs.
-const mainIndexContent = `// Provide named exports for each package
+// Create the main index.js file that re-exports everything.
+const mainIndexContent = `// Re-export all packages from their respective modules
+export * from './base/index.js';
+export * from './core/index.js';
+export * from './react/index.js';
+export * from './sst/index.js';
+
+// Also provide named exports for each package
 export * as base from './base/index.js';
 export * as core from './core/index.js';
 export * as react from './react/index.js';
@@ -103,7 +109,13 @@ export * as sst from './sst/index.js';
 fs.writeFileSync(path.join(distDir, 'index.js'), mainIndexContent);
 
 // Create the main index.d.ts file
-const mainIndexDtsContent = `// Provide named exports for each package
+const mainIndexDtsContent = `// Re-export all packages from their respective modules
+export * from './base/index';
+export * from './core/index';
+export * from './react/index';
+export * from './sst/index';
+
+// Also provide named exports for each package
 export * as base from './base/index';
 export * as core from './core/index';
 export * as react from './react/index';

--- a/packages/monorise/build.js
+++ b/packages/monorise/build.js
@@ -92,14 +92,8 @@ packages.forEach((pkg) => {
   }
 });
 
-// Create the main index.js file that re-exports everything
-const mainIndexContent = `// Re-export all packages from their respective modules
-export * from './base/index.js';
-export * from './core/index.js';
-export * from './react/index.js';
-export * from './sst/index.js';
-
-// Also provide named exports for each package
+// Create a root entrypoint that exposes packages without flattening their APIs.
+const mainIndexContent = `// Provide named exports for each package
 export * as base from './base/index.js';
 export * as core from './core/index.js';
 export * as react from './react/index.js';
@@ -109,13 +103,7 @@ export * as sst from './sst/index.js';
 fs.writeFileSync(path.join(distDir, 'index.js'), mainIndexContent);
 
 // Create the main index.d.ts file
-const mainIndexDtsContent = `// Re-export all packages from their respective modules
-export * from './base/index';
-export * from './core/index';
-export * from './react/index';
-export * from './sst/index';
-
-// Also provide named exports for each package
+const mainIndexDtsContent = `// Provide named exports for each package
 export * as base from './base/index';
 export * as core from './core/index';
 export * as react from './react/index';

--- a/packages/monorise/build.js
+++ b/packages/monorise/build.js
@@ -2,7 +2,7 @@
 
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -109,27 +109,55 @@ export * as sst from './sst/index.js';
 fs.writeFileSync(path.join(distDir, 'index.js'), mainIndexContent);
 
 // Create the main index.d.ts file.
-// Core and React declare different `transactional` builders, so star-exporting
-// both would emit TS2308. Runtime star-exports already drop the ambiguous name
-// (ESM semantics); enumerate Core and React exports here minus `transactional`
-// so the type surface matches the runtime surface. Names exported by both
-// (e.g. `Mutual`) resolve to Core's, matching star-export behavior.
+// ESM star-exports drop ambiguous names from the runtime namespace (e.g.
+// `transactional`, declared by both Core and React, and `Entity`, exported as
+// different values by base and Core), while TS reports TS2308 for them. To
+// keep the type surface identical to the runtime surface, enumerate every
+// package's exports explicitly: names ambiguous at runtime are omitted, and
+// names declared by more than one package are claimed by the first package
+// listed (same-symbol re-exports from base, and type-only re-exports such as
+// React's `Mutual`, which tsup elides at runtime).
+const dtsPackages = ['core', 'base', 'react', 'sst'];
+
+const runtimeAmbiguous = async () => {
+  const counts = new Map();
+  for (const pkg of dtsPackages) {
+    const mod = await import(
+      pathToFileURL(path.join(distDir, pkg, 'index.js')).href
+    );
+    for (const name of Object.keys(mod)) {
+      if (name !== 'default') {
+        counts.set(name, (counts.get(name) ?? 0) + 1);
+      }
+    }
+  }
+  return new Set(
+    [...counts].filter(([, count]) => count > 1).map(([name]) => name),
+  );
+};
+
 const getDtsExportNames = (pkg) => {
   const dts = fs.readFileSync(path.join(distDir, pkg, 'index.d.ts'), 'utf-8');
   const names = new Set();
-  const exportClause = /export\s+(?:type\s+)?\{([^}]*)\}/g;
   let match;
+  const exportClause = /export\s+(?:type\s+)?\{([^}]*)\}/g;
   while ((match = exportClause.exec(dts)) !== null) {
     for (const part of match[1].split(',')) {
       const name = part
         .trim()
         .split(/\s+as\s+/)
         .pop()
-        .trim();
+        .trim()
+        .replace(/^type\s+/, '');
       if (name && name !== 'default') {
         names.add(name);
       }
     }
+  }
+  const exportDeclare =
+    /export\s+declare\s+(?:const|let|var|function|class|interface|type|enum|namespace)\s+([A-Za-z_$][\w$]*)/g;
+  while ((match = exportDeclare.exec(dts)) !== null) {
+    names.add(match[1]);
   }
   if (names.size === 0) {
     throw new Error(`Failed to enumerate exports from ${pkg}/index.d.ts`);
@@ -137,22 +165,26 @@ const getDtsExportNames = (pkg) => {
   return names;
 };
 
-const coreNames = getDtsExportNames('core');
-coreNames.delete('transactional');
-const reactNames = getDtsExportNames('react');
-reactNames.delete('transactional');
-for (const name of coreNames) {
-  reactNames.delete(name);
-}
-
-const toExportClause = (names, pkg) =>
-  `export {\n${[...names].map((name) => `  ${name},`).join('\n')}\n} from './${pkg}/index';`;
+const ambiguous = await runtimeAmbiguous();
+const claimed = new Set();
+const dtsClauses = dtsPackages
+  .map((pkg) => {
+    const names = [...getDtsExportNames(pkg)].filter(
+      (name) => !ambiguous.has(name) && !claimed.has(name),
+    );
+    for (const name of names) {
+      claimed.add(name);
+    }
+    if (names.length === 0) {
+      return '';
+    }
+    return `export {\n${names.map((name) => `  ${name},`).join('\n')}\n} from './${pkg}/index';`;
+  })
+  .filter(Boolean)
+  .join('\n');
 
 const mainIndexDtsContent = `// Re-export all packages from their respective modules
-export * from './base/index';
-${toExportClause(coreNames, 'core')}
-${toExportClause(reactNames, 'react')}
-export * from './sst/index';
+${dtsClauses}
 
 // Also provide named exports for each package
 export * as base from './base/index';

--- a/packages/monorise/build.js
+++ b/packages/monorise/build.js
@@ -108,11 +108,50 @@ export * as sst from './sst/index.js';
 
 fs.writeFileSync(path.join(distDir, 'index.js'), mainIndexContent);
 
-// Create the main index.d.ts file
+// Create the main index.d.ts file.
+// Core and React declare different `transactional` builders, so star-exporting
+// both would emit TS2308. Runtime star-exports already drop the ambiguous name
+// (ESM semantics); enumerate Core and React exports here minus `transactional`
+// so the type surface matches the runtime surface. Names exported by both
+// (e.g. `Mutual`) resolve to Core's, matching star-export behavior.
+const getDtsExportNames = (pkg) => {
+  const dts = fs.readFileSync(path.join(distDir, pkg, 'index.d.ts'), 'utf-8');
+  const names = new Set();
+  const exportClause = /export\s+(?:type\s+)?\{([^}]*)\}/g;
+  let match;
+  while ((match = exportClause.exec(dts)) !== null) {
+    for (const part of match[1].split(',')) {
+      const name = part
+        .trim()
+        .split(/\s+as\s+/)
+        .pop()
+        .trim();
+      if (name && name !== 'default') {
+        names.add(name);
+      }
+    }
+  }
+  if (names.size === 0) {
+    throw new Error(`Failed to enumerate exports from ${pkg}/index.d.ts`);
+  }
+  return names;
+};
+
+const coreNames = getDtsExportNames('core');
+coreNames.delete('transactional');
+const reactNames = getDtsExportNames('react');
+reactNames.delete('transactional');
+for (const name of coreNames) {
+  reactNames.delete(name);
+}
+
+const toExportClause = (names, pkg) =>
+  `export {\n${[...names].map((name) => `  ${name},`).join('\n')}\n} from './${pkg}/index';`;
+
 const mainIndexDtsContent = `// Re-export all packages from their respective modules
 export * from './base/index';
-export * from './core/index';
-export * from './react/index';
+${toExportClause(coreNames, 'core')}
+${toExportClause(reactNames, 'react')}
 export * from './sst/index';
 
 // Also provide named exports for each package

--- a/packages/react/helpers/transactional.ts
+++ b/packages/react/helpers/transactional.ts
@@ -1,13 +1,13 @@
 import type { Entity, EntitySchemaMap } from '@monorise/base';
 
-type TransactionCreateEntity<T extends Entity> = {
+export type TransactionCreateEntity<T extends Entity = Entity> = {
   operation: 'createEntity';
   entityType: T;
   entityId?: string;
   payload: EntitySchemaMap[T];
 };
 
-type TransactionUpdateEntity<T extends Entity> = {
+export type TransactionUpdateEntity<T extends Entity = Entity> = {
   operation: 'updateEntity';
   entityType: T;
   entityId: string;
@@ -15,7 +15,7 @@ type TransactionUpdateEntity<T extends Entity> = {
   condition?: string;
 };
 
-type TransactionAdjustEntity<T extends Entity> = {
+export type TransactionAdjustEntity<T extends Entity = Entity> = {
   operation: 'adjustEntity';
   entityType: T;
   entityId: string;
@@ -23,11 +23,17 @@ type TransactionAdjustEntity<T extends Entity> = {
   condition?: string;
 };
 
-type TransactionDeleteEntity<T extends Entity> = {
+export type TransactionDeleteEntity<T extends Entity = Entity> = {
   operation: 'deleteEntity';
   entityType: T;
   entityId: string;
 };
+
+export type TransactionOperation =
+  | TransactionCreateEntity
+  | TransactionUpdateEntity
+  | TransactionAdjustEntity
+  | TransactionDeleteEntity;
 
 export const transactional = {
   createEntity: <T extends Entity>(
@@ -41,7 +47,7 @@ export const transactional = {
       operation: 'createEntity',
       entityType,
       payload: rest as EntitySchemaMap[T],
-      ...(entityId && { entityId }),
+      ...(entityId !== undefined && { entityId }),
     };
   },
 
@@ -58,7 +64,7 @@ export const transactional = {
       entityType,
       entityId,
       payload: rest as Partial<EntitySchemaMap[T]>,
-      ...($condition && { condition: $condition }),
+      ...($condition !== undefined && { condition: $condition }),
     };
   },
 
@@ -73,7 +79,7 @@ export const transactional = {
       entityType,
       entityId,
       adjustments: rest,
-      ...($condition && { condition: $condition }),
+      ...($condition !== undefined && { condition: $condition }),
     };
   },
 

--- a/packages/react/helpers/transactional.ts
+++ b/packages/react/helpers/transactional.ts
@@ -35,6 +35,9 @@ export type TransactionOperation =
   | TransactionAdjustEntity
   | TransactionDeleteEntity;
 
+// NOTE: packages/core/helpers/transactional.ts is the server-side copy of
+// this builder. Both emit the same wire format for the execute-transaction
+// endpoint — keep operation shapes in sync when changing either file.
 export const transactional = {
   createEntity: <T extends Entity>(
     entityType: T,

--- a/packages/react/helpers/transactional.ts
+++ b/packages/react/helpers/transactional.ts
@@ -1,0 +1,88 @@
+import type { Entity, EntitySchemaMap } from '@monorise/base';
+
+type TransactionCreateEntity<T extends Entity> = {
+  operation: 'createEntity';
+  entityType: T;
+  entityId?: string;
+  payload: EntitySchemaMap[T];
+};
+
+type TransactionUpdateEntity<T extends Entity> = {
+  operation: 'updateEntity';
+  entityType: T;
+  entityId: string;
+  payload: Partial<EntitySchemaMap[T]>;
+  condition?: string;
+};
+
+type TransactionAdjustEntity<T extends Entity> = {
+  operation: 'adjustEntity';
+  entityType: T;
+  entityId: string;
+  adjustments: Record<string, number>;
+  condition?: string;
+};
+
+type TransactionDeleteEntity<T extends Entity> = {
+  operation: 'deleteEntity';
+  entityType: T;
+  entityId: string;
+};
+
+export const transactional = {
+  createEntity: <T extends Entity>(
+    entityType: T,
+    payload: EntitySchemaMap[T] & { entityId?: string },
+  ): TransactionCreateEntity<T> => {
+    const { entityId, ...rest } = payload as EntitySchemaMap[T] & {
+      entityId?: string;
+    };
+    return {
+      operation: 'createEntity',
+      entityType,
+      payload: rest as EntitySchemaMap[T],
+      ...(entityId && { entityId }),
+    };
+  },
+
+  updateEntity: <T extends Entity>(
+    entityType: T,
+    entityId: string,
+    payload: Partial<EntitySchemaMap[T]> & { $condition?: string },
+  ): TransactionUpdateEntity<T> => {
+    const { $condition, ...rest } = payload as Partial<EntitySchemaMap[T]> & {
+      $condition?: string;
+    };
+    return {
+      operation: 'updateEntity',
+      entityType,
+      entityId,
+      payload: rest as Partial<EntitySchemaMap[T]>,
+      ...($condition && { condition: $condition }),
+    };
+  },
+
+  adjustEntity: <T extends Entity>(
+    entityType: T,
+    entityId: string,
+    adjustments: Record<string, number> & { $condition?: string },
+  ): TransactionAdjustEntity<T> => {
+    const { $condition, ...rest } = adjustments;
+    return {
+      operation: 'adjustEntity',
+      entityType,
+      entityId,
+      adjustments: rest,
+      ...($condition && { condition: $condition }),
+    };
+  },
+
+  deleteEntity: <T extends Entity>(
+    entityType: T,
+    entityId: string,
+  ): TransactionDeleteEntity<T> => ({
+    operation: 'deleteEntity',
+    entityType,
+    entityId,
+  }),
+};

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -22,6 +22,8 @@ import {
   MutualDataWithIndex,
 } from './types/mutual.type';
 
+export { transactional } from './helpers/transactional';
+
 type Options<T extends Record<string, React.ComponentType<any>>> = {
   authBaseUrl?: string;
   filestoreBaseUrl?: string;
@@ -208,7 +210,6 @@ export {
 
 export default Monorise;
 
-export { transactional } from '@monorise/core';
 export { MutualDataWithIndex, MutualDataMapping, MutualData, Mutual };
 
 export type {

--- a/packages/react/index.ts
+++ b/packages/react/index.ts
@@ -22,8 +22,6 @@ import {
   MutualDataWithIndex,
 } from './types/mutual.type';
 
-export { transactional } from './helpers/transactional';
-
 type Options<T extends Record<string, React.ComponentType<any>>> = {
   authBaseUrl?: string;
   filestoreBaseUrl?: string;
@@ -210,6 +208,7 @@ export {
 
 export default Monorise;
 
+export { transactional } from './helpers/transactional';
 export { MutualDataWithIndex, MutualDataMapping, MutualData, Mutual };
 
 export type {
@@ -219,3 +218,4 @@ export type {
   EntitySchemaMap,
   NumericFields,
 } from '@monorise/base';
+export type { TransactionOperation } from './helpers/transactional';

--- a/packages/react/services/core.service.ts
+++ b/packages/react/services/core.service.ts
@@ -1,5 +1,6 @@
 import type { CreatedEntity, DraftEntity, Entity } from '@monorise/base';
 import type { AxiosRequestConfig } from 'axios';
+import type { TransactionOperation } from '../helpers/transactional';
 import {
   getEntityRequestKey,
   getMutualRequestKey,
@@ -277,18 +278,7 @@ const initCoreService = (
   };
 
   const transaction = (
-    operations: Array<{
-      operation:
-        | 'createEntity'
-        | 'updateEntity'
-        | 'adjustEntity'
-        | 'deleteEntity';
-      entityType: Entity;
-      entityId?: string;
-      payload?: Record<string, unknown>;
-      adjustments?: Record<string, number>;
-      condition?: string;
-    }>,
+    operations: TransactionOperation[],
     opts: CommonOptions = {},
   ) => {
     const { transactionApiBaseUrl = TRANSACTION_API_BASE_URL } =

--- a/turbo.json
+++ b/turbo.json
@@ -3,6 +3,16 @@
     "build": {
       "outputs": ["dist/**"]
     },
+    "monorise#build": {
+      "dependsOn": [
+        "@monorise/base#build",
+        "@monorise/core#build",
+        "@monorise/react#build",
+        "@monorise/sst#build",
+        "@monorise/cli#build"
+      ],
+      "outputs": ["dist/**"]
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## Summary
- implement the `transactional` operation builder in `@monorise/react`
- preserve the `monorise/react` public API without re-exporting `@monorise/core`
- add patch releases for `@monorise/react` and `monorise`

## Why
Re-exporting `transactional` from Core pulls AWS SDK and Node-only modules (`fs`, `async_hooks`) into frontend bundles. Next.js applications importing `monorise/react` then fail browser compilation even when they do not use `transactional`.

## Verification
- `npm run build`
- packed the generated `monorise` package and installed it in an isolated Humanthis checkout
- confirmed Backoffice Webpack compilation proceeds past the prior Node-module resolution errors