### PR TITLE
docs: refresh product and deployment guidance

### DIFF
--- a/.changeset/curly-cats-rotate.md
+++ b/.changeset/curly-cats-rotate.md
@@ -1,7 +1,6 @@
 ---
 '@monorise/cli': patch
-'@monorise/sst': patch
 'monorise': patch
 ---
 
-Create and expose an `X_API_KEY` secret from `MonoriseCore`, and generate backend proxies that link the selected key instead of embedding it in the Next.js environment.
+Generate an application-owned `X_API_KEY` secret for backend proxies instead of embedding the selected Core API key in the Next.js environment.

--- a/.changeset/curly-cats-rotate.md
+++ b/.changeset/curly-cats-rotate.md
@@ -1,6 +1,7 @@
 ---
 '@monorise/cli': patch
+'@monorise/sst': patch
 'monorise': patch
 ---
 
-Generate an `X_API_KEY` SST secret for the backend proxy instead of embedding the selected Core API key in the Next.js environment.
+Create and expose an `X_API_KEY` secret from `MonoriseCore`, and generate backend proxies that link the selected key instead of embedding it in the Next.js environment.

--- a/.changeset/curly-cats-rotate.md
+++ b/.changeset/curly-cats-rotate.md
@@ -1,0 +1,6 @@
+---
+'@monorise/cli': patch
+'monorise': patch
+---
+
+Generate an `X_API_KEY` SST secret for the backend proxy instead of embedding the selected Core API key in the Next.js environment.

--- a/.changeset/tidy-dingos-update.md
+++ b/.changeset/tidy-dingos-update.md
@@ -1,0 +1,6 @@
+---
+'@monorise/core': patch
+'monorise': patch
+---
+
+Return 404 instead of 500 when a named function update condition targets a missing entity.

--- a/packages/cli/templates/files/proxy-request.ts
+++ b/packages/cli/templates/files/proxy-request.ts
@@ -1,4 +1,5 @@
 import type { NextRequest } from 'next/server';
+import { Resource } from 'sst';
 
 function rewriteUrl({
   requestUrl,
@@ -39,7 +40,7 @@ export const proxyRequest = async ({
       body,
       headers: {
         ...reqHeaders,
-        'x-api-key': process.env.API_KEY ?? '',
+        'x-api-key': Resource.X_API_KEY.value,
       },
       cache: 'no-store',
     },

--- a/packages/cli/templates/files/sst.config.ts
+++ b/packages/cli/templates/files/sst.config.ts
@@ -12,10 +12,9 @@ export default $config({
   async run() {
     const { monorise } = await import('monorise/sst');
 
-    const { api } = new monorise.module.Core('core', {
+    const { api, xApiKey } = new monorise.module.Core('core', {
       allowOrigins: ['http://localhost:3000'],
     });
-    const xApiKey = new sst.Secret('X_API_KEY', 'secret1');
 
     new sst.aws.Nextjs('web', {
       path: 'apps/web',

--- a/packages/cli/templates/files/sst.config.ts
+++ b/packages/cli/templates/files/sst.config.ts
@@ -12,9 +12,10 @@ export default $config({
   async run() {
     const { monorise } = await import('monorise/sst');
 
-    const { api, xApiKey } = new monorise.module.Core('core', {
+    const { api } = new monorise.module.Core('core', {
       allowOrigins: ['http://localhost:3000'],
     });
+    const xApiKey = new sst.Secret('X_API_KEY', 'secret1');
 
     new sst.aws.Nextjs('web', {
       path: 'apps/web',

--- a/packages/cli/templates/files/sst.config.ts
+++ b/packages/cli/templates/files/sst.config.ts
@@ -15,6 +15,9 @@ export default $config({
     const { api } = new monorise.module.Core('core', {
       allowOrigins: ['http://localhost:3000'],
     });
+    // Must match one entry in Core's API_KEYS secret (defaults to
+    // ["secret1", "secret2"]). Override both before deploying:
+    // npx sst secret set X_API_KEY '...' && npx sst secret set API_KEYS '["..."]'
     const xApiKey = new sst.Secret('X_API_KEY', 'secret1');
 
     new sst.aws.Nextjs('web', {

--- a/packages/cli/templates/files/sst.config.ts
+++ b/packages/cli/templates/files/sst.config.ts
@@ -15,15 +15,13 @@ export default $config({
     const { api } = new monorise.module.Core('core', {
       allowOrigins: ['http://localhost:3000'],
     });
+    const xApiKey = new sst.Secret('X_API_KEY', 'secret1');
 
     new sst.aws.Nextjs('web', {
       path: 'apps/web',
+      link: [api, xApiKey],
       environment: {
         API_BASE_URL: api.url,
-        // Must match one of the values in the backend's API_KEYS secret
-        // (defaults to ["secret1", "secret2"] — override both with
-        // `npx sst secret set API_KEYS '["..."]'` before deploying).
-        API_KEY: 'secret1',
       },
     });
   },

--- a/packages/core/controllers/entity/update-entity.controller.ts
+++ b/packages/core/controllers/entity/update-entity.controller.ts
@@ -59,7 +59,8 @@ export class UpdateEntityController {
 
       if (
         err instanceof StandardError &&
-        err.code === StandardErrorCode.ENTITY_NOT_FOUND
+        (err.code === StandardErrorCode.ENTITY_NOT_FOUND ||
+          err.code === StandardErrorCode.ENTITY_IS_UNDEFINED)
       ) {
         c.status(httpStatus.NOT_FOUND);
         return c.json({

--- a/packages/core/data/__tests__/ConditionalUpdateEntityHttp.test.ts
+++ b/packages/core/data/__tests__/ConditionalUpdateEntityHttp.test.ts
@@ -535,6 +535,16 @@ describe('HTTP — conditional updateEntity ($where body key)', () => {
       expect(status).toBe(400);
       expect(data.code).toBe('INVALID_CONDITION');
     });
+
+    it('9.6 — function condition on missing entity → 404', async () => {
+      const { status, data } = await patch(
+        MockEntityType.WALLET,
+        'non-existent-id',
+        { status: 'archived', $condition: 'archive' },
+      );
+      expect(status).toBe(404);
+      expect(data.code).toBe('ENTITY_IS_UNDEFINED');
+    });
   });
 
   // ─── Group 10: allowLegacyWhere (security default) ────────────────────────

--- a/packages/core/helpers/test/test-utils.ts
+++ b/packages/core/helpers/test/test-utils.ts
@@ -126,6 +126,7 @@ export const createMockEntityConfig = () => ({
     },
     updateConditions: {
       publish: { status: { $eq: 'draft' } },
+      archive: (_data) => ({ status: { $ne: 'archived' } }),
     },
     // Opted in so the legacy $where test suite can still exercise its mechanics.
     allowLegacyWhere: true,

--- a/packages/sst/components/monorise-core.ts
+++ b/packages/sst/components/monorise-core.ts
@@ -26,6 +26,7 @@ export class MonoriseCore {
   public readonly bus: sst.aws.Bus;
   public readonly table: SingleTable;
   public readonly alarmTopic: sst.aws.SnsTopic;
+  public readonly xApiKey: sst.Secret;
 
   constructor(id: string, args?: MonoriseCoreArgs) {
     const runtime: sst.aws.FunctionArgs['runtime'] = 'nodejs22.x';
@@ -68,6 +69,7 @@ export class MonoriseCore {
     });
 
     const secretApiKeys = new sst.Secret('API_KEYS', '["secret1", "secret2"]');
+    this.xApiKey = new sst.Secret('X_API_KEY', 'secret1');
 
     const appHandlerName = `${$app.stage}-${$app.name}-${id}-app-handler`;
     this.api.route('ANY /core/{proxy+}', {

--- a/packages/sst/components/monorise-core.ts
+++ b/packages/sst/components/monorise-core.ts
@@ -26,7 +26,6 @@ export class MonoriseCore {
   public readonly bus: sst.aws.Bus;
   public readonly table: SingleTable;
   public readonly alarmTopic: sst.aws.SnsTopic;
-  public readonly xApiKey: sst.Secret;
 
   constructor(id: string, args?: MonoriseCoreArgs) {
     const runtime: sst.aws.FunctionArgs['runtime'] = 'nodejs22.x';
@@ -69,7 +68,6 @@ export class MonoriseCore {
     });
 
     const secretApiKeys = new sst.Secret('API_KEYS', '["secret1", "secret2"]');
-    this.xApiKey = new sst.Secret('X_API_KEY', 'secret1');
 
     const appHandlerName = `${$app.stage}-${$app.name}-${id}-app-handler`;
     this.api.route('ANY /core/{proxy+}', {

--- a/www/docs/.vitepress/config.ts
+++ b/www/docs/.vitepress/config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
           { text: 'Entities', link: '/concepts/entities' },
           { text: 'Mutuals', link: '/concepts/mutuals' },
           { text: 'Tags', link: '/concepts/tags' },
-          { text: 'Prejoins', link: '/concepts/prejoins' },
+          { text: 'Tree Processors', link: '/concepts/prejoins' },
         ],
       },
       {

--- a/www/docs/architecture.md
+++ b/www/docs/architecture.md
@@ -98,7 +98,7 @@ Define named `updateConditions` in the entity config, then send the permitted co
 `$condition` is optional for entity updates, but required for adjustments when the entity defines `adjustmentConditions`. A failed condition returns `409 CONFLICT`. See [Entities: Conditional writes](/concepts/entities#conditional-writes) for configuration examples.
 
 ::: warning Legacy `$where`
-Raw `$where` conditions are deprecated and disabled by default. Enable `allowLegacyWhere` only for trusted compatibility callers; new clients must use named conditions.
+Raw `$where` conditions are deprecated and disabled by default. Enable `allowLegacyWhere` only for trusted compatibility callers; new clients must use named conditions. A compatibility request places the raw clauses under `$where`, for example `{ "status": "confirmed", "$where": { "status": { "$eq": "pending" } } }`.
 :::
 
 ## Data layout cheat sheet

--- a/www/docs/architecture.md
+++ b/www/docs/architecture.md
@@ -105,8 +105,8 @@ Define named `updateConditions` in the entity config, then send the permitted co
 Response behavior for `PATCH`:
 
 - `200 OK`: update applied
-- `409 CONFLICT`: condition failed (`CONDITIONAL_CHECK_FAILED`); in conditional mode this also covers a missing entity
-- `404 NOT_FOUND`: entity missing in non-conditional mode only
+- `409 CONFLICT`: condition failed (`CONDITIONAL_CHECK_FAILED`); a static condition on a missing entity also lands here
+- `404 NOT_FOUND`: entity missing without a condition or while resolving a function condition
 - `400 BAD_REQUEST`: validation errors, unique-value conflicts, or an unknown/undefined condition name
 
 ::: warning Legacy `$where`

--- a/www/docs/architecture.md
+++ b/www/docs/architecture.md
@@ -63,7 +63,6 @@ The default Hono API exposes the following routes under `/core`. All entity rout
 | `PATCH` | `/entity/:entityType/:entityId` | Update entity (partial); supports optional named `$condition` |
 | `DELETE` | `/entity/:entityType/:entityId` | Delete entity |
 | `POST` | `/entity/:entityType/:entityId/adjust` | Atomic numeric adjustment (body: `{ field: delta }`) |
-| `POST` | `/transaction` | Execute entity operations atomically |
 
 ### Mutual endpoints
 
@@ -79,7 +78,13 @@ The default Hono API exposes the following routes under `/core`. All entity rout
 
 | Method | Route | Description |
 |--------|-------|-------------|
-| `GET` | `/tag/:entityType/:tagName` | Query tagged entities (`?group=...&start=...&end=...`) |
+| `GET` | `/tag/:entityType/:tagName` | Query tagged entities (`?group=...&query=...&start=...&end=...&limit=...&lastKey=...`) |
+
+### Transaction endpoint
+
+| Method | Route | Description |
+|--------|-------|-------------|
+| `POST` | `/transaction` | Execute entity operations atomically |
 
 Custom routes can be mounted under `/core/app/*` via `customRoutes` in your monorise config.
 
@@ -96,6 +101,13 @@ Define named `updateConditions` in the entity config, then send the permitted co
 ```
 
 `$condition` is optional for entity updates, but required for adjustments when the entity defines `adjustmentConditions`. A failed condition returns `409 CONFLICT`. See [Entities: Conditional writes](/concepts/entities#conditional-writes) for configuration examples.
+
+Response behavior for `PATCH`:
+
+- `200 OK`: update applied
+- `409 CONFLICT`: condition failed (`CONDITIONAL_CHECK_FAILED`); in conditional mode this also covers a missing entity
+- `404 NOT_FOUND`: entity missing in non-conditional mode only
+- `400 BAD_REQUEST`: validation errors, unique-value conflicts, or an unknown/undefined condition name
 
 ::: warning Legacy `$where`
 Raw `$where` conditions are deprecated and disabled by default. Enable `allowLegacyWhere` only for trusted compatibility callers; new clients must use named conditions. A compatibility request places the raw clauses under `$where`, for example `{ "status": "confirmed", "$where": { "status": { "$eq": "pending" } } }`.

--- a/www/docs/architecture.md
+++ b/www/docs/architecture.md
@@ -27,7 +27,7 @@ The architecture consists of:
 
 ### QFunction (processor pattern)
 
-Each processor (mutual, tag, prejoin) uses the **QFunction** pattern — an SQS queue paired with a Lambda function, a Dead Letter Queue for failed messages, and a CloudWatch alarm that notifies via Slack when messages land in the DLQ:
+Each event-driven processor (mutual, tag, tree) uses the **QFunction** pattern — an SQS queue paired with a Lambda function, a Dead Letter Queue for failed messages, and a CloudWatch alarm that publishes to an SNS topic when messages land in the DLQ:
 
 ![Monorise QFunction](/monorise-q-function.png)
 
@@ -36,7 +36,7 @@ The flow:
 2. **Lambda** processes the message (e.g., syncs mutual records, recalculates tags)
 3. If processing fails, the message moves to the **DLQ** after retry exhaustion
 4. A **CloudWatch Alarm** fires when the DLQ depth exceeds 0
-5. The alarm sends a notification to **Slack** (if `slackWebhook` is configured)
+5. The alarm publishes to the configured **SNS topic**
 
 Failed messages can be redriven from the DLQ once the issue is resolved.
 
@@ -44,7 +44,7 @@ Failed messages can be redriven from the DLQ once the issue is resolved.
 
 - **Mutual processor**: creates/updates/removes relationship items in both directions with conditional checks and locking.
 - **Tag processor**: calculates tag diffs and syncs tag items.
-- **Prejoin processor**: walks configured relationship paths and publishes derived mutual updates.
+- **Tree processor**: walks configured relationship paths and publishes derived mutual updates.
 - **Replication processor**: keeps denormalized copies aligned via stream updates (uses replication indexes).
 
 ## API reference
@@ -60,9 +60,10 @@ The default Hono API exposes the following routes under `/core`. All entity rout
 | `GET` | `/entity/:entityType/unique/:field/:value` | Get entity by unique field |
 | `GET` | `/entity/:entityType/:entityId` | Get entity by ID |
 | `PUT` | `/entity/:entityType/:entityId` | Upsert entity (full replacement) |
-| `PATCH` | `/entity/:entityType/:entityId` | Update entity (partial); supports optional [`$where` conditions](#conditional-updates-where) |
+| `PATCH` | `/entity/:entityType/:entityId` | Update entity (partial); supports optional named `$condition` |
 | `DELETE` | `/entity/:entityType/:entityId` | Delete entity |
 | `POST` | `/entity/:entityType/:entityId/adjust` | Atomic numeric adjustment (body: `{ field: delta }`) |
+| `POST` | `/transaction` | Execute entity operations atomically |
 
 ### Mutual endpoints
 
@@ -82,71 +83,23 @@ The default Hono API exposes the following routes under `/core`. All entity rout
 
 Custom routes can be mounted under `/core/app/*` via `customRoutes` in your monorise config.
 
-### Conditional updates (`$where`)
+### Conditional updates (`$condition`)
 
-Use `$where` in `PATCH /core/entity/:entityType/:entityId` when updates should
-only apply if current values match your preconditions. Monorise compiles this
-to a DynamoDB `ConditionExpression` and executes it atomically in one write.
-
-Without `$where` (existing behavior):
-
-```json
-{
-  "status": "confirmed"
-}
-```
-
-With `$where`:
+Define named `updateConditions` in the entity config, then send the permitted condition name with the update. The server resolves the name to a DynamoDB `ConditionExpression`; raw operators never need to be client-facing.
 
 ```json
 {
   "status": "confirmed",
   "confirmedAt": "2026-04-13T00:00:00.000Z",
-  "$where": {
-    "status": { "$eq": "pending" },
-    "retryCount": { "$lt": 3 }
-  }
+  "$condition": "confirm"
 }
 ```
 
-Shorthand equality is supported:
+`$condition` is optional for entity updates, but required for adjustments when the entity defines `adjustmentConditions`. A failed condition returns `409 CONFLICT`. See [Entities: Conditional writes](/concepts/entities#conditional-writes) for configuration examples.
 
-```json
-{
-  "status": "confirmed",
-  "$where": {
-    "status": "pending"
-  }
-}
-```
-
-All `$where` clauses are combined with `AND`.
-
-Supported operators:
-
-| Operator | Meaning |
-|---|---|
-| `$eq` | Equals |
-| `$ne` | Not equals |
-| `$gt` | Greater than |
-| `$lt` | Less than |
-| `$gte` | Greater than or equal |
-| `$lte` | Less than or equal |
-| `$exists` | Field exists / does not exist |
-| `$beginsWith` | String prefix match |
-
-Response behavior for PATCH:
-
-- `200 OK`: update applied
-- `409 CONFLICT`: `$where` precondition failed (`CONDITIONAL_CHECK_FAILED`)
-  - in conditional mode, this also includes missing entities
-- `404 NOT_FOUND`: entity missing in non-conditional mode
-- `400 BAD_REQUEST`: validation errors and unique-value conflicts
-
-Compatibility notes:
-
-- Existing PATCH clients continue to work unchanged (no `$where` required).
-- Top-level `$where` is reserved for conditional update semantics.
+::: warning Legacy `$where`
+Raw `$where` conditions are deprecated and disabled by default. Enable `allowLegacyWhere` only for trusted compatibility callers; new clients must use named conditions.
+:::
 
 ## Data layout cheat sheet
 

--- a/www/docs/best-practices.md
+++ b/www/docs/best-practices.md
@@ -14,11 +14,10 @@ The frontend server is a **thin proxy layer** — its only job is to authenticat
 
 SST provides seamless Next.js deployment via `sst.aws.Nextjs`. This means your Next.js app already has a server — use its API routes as the proxy layer. No extra infrastructure needed.
 
-Create an `X_API_KEY` secret and link it to the Next.js server. Its value must match one of the keys accepted by Monorise Core's `API_KEYS` secret:
+Monorise Core creates both the `API_KEYS` allow-list and an `X_API_KEY` secret. Link `xApiKey` to the Next.js server so only your backend proxy can read the selected key:
 
 ```ts
-const { api } = new monorise.module.Core('core');
-const xApiKey = new sst.Secret('X_API_KEY', 'secret1');
+const { api, xApiKey } = new monorise.module.Core('core');
 
 new sst.aws.Nextjs('web', {
   link: [api, xApiKey],

--- a/www/docs/best-practices.md
+++ b/www/docs/best-practices.md
@@ -14,11 +14,26 @@ The frontend server is a **thin proxy layer** — its only job is to authenticat
 
 SST provides seamless Next.js deployment via `sst.aws.Nextjs`. This means your Next.js app already has a server — use its API routes as the proxy layer. No extra infrastructure needed.
 
+Create an `X_API_KEY` secret and link it to the Next.js server. Its value must match one of the keys accepted by Monorise Core's `API_KEYS` secret:
+
+```ts
+const { api } = new monorise.module.Core('core');
+const xApiKey = new sst.Secret('X_API_KEY', 'secret1');
+
+new sst.aws.Nextjs('web', {
+  link: [api, xApiKey],
+  environment: {
+    API_BASE_URL: api.url,
+  },
+});
+```
+
 **1. Proxy utility** — rewrites client requests to the monorise API Gateway, validates auth, and attaches `x-api-key`:
 
 ```ts
 // app/api/proxy-request.ts
 import { type NextRequest, NextResponse } from 'next/server';
+import { Resource } from 'sst';
 import { validateToken } from './validate-token';
 
 function rewriteUrl(requestUrl: string, replacePath?: string) {
@@ -55,7 +70,7 @@ export const proxyRequest = async ({
     headers: {
       'content-type': 'application/json',
       'account-id': accountId,
-      'x-api-key': process.env.API_KEY ?? '',
+      'x-api-key': Resource.X_API_KEY.value,
     },
     cache: 'no-store',
   });
@@ -114,23 +129,25 @@ Now all client-side hooks (`useEntities`, `useMutuals`, etc.) route through your
 
 Don't reuse the same API key across environments. Configure separate keys for development, staging, and production via the `API_KEYS` SST secret:
 
-`API_KEYS` is used by the monorise API Gateway to authenticate incoming requests. The generated proxy reads the singular `API_KEY` environment variable, configured on the `sst.aws.Nextjs` resource in `sst.config.ts`; its value must match one entry in `API_KEYS`.
+The two secrets have separate responsibilities:
+
+| Secret | Purpose |
+|--------|---------|
+| `API_KEYS` | Rotatable allow-list used by Monorise Core to verify requests |
+| `X_API_KEY` | One selected key held by your backend proxy and attached as the `x-api-key` request header |
 
 ```bash
 # API Gateway accepts these keys (array of valid keys)
 npx sst secret set API_KEYS '["dev-key-123"]' --stage dev
 npx sst secret set API_KEYS '["prod-key-abc"]' --stage production
-```
 
-```ts
-// In sst.config.ts, replace the generated default for each stage:
-environment: {
-  API_KEY: 'dev-key-123',
-}
+# Backend proxy sends one accepted key
+npx sst secret set X_API_KEY 'dev-key-123' --stage dev
+npx sst secret set X_API_KEY 'prod-key-abc' --stage production
 ```
 
 ::: tip
-`API_KEYS` is an array because you may have multiple valid keys (e.g., for key rotation). `API_KEY` is the single key your generated proxy uses — it must match one of the values in `API_KEYS`.
+`API_KEYS` is an array so old and new keys can overlap during rotation. `X_API_KEY` is the single key sent by the proxy and must match one value in that array.
 :::
 
 ## Keep entity configs focused

--- a/www/docs/best-practices.md
+++ b/www/docs/best-practices.md
@@ -14,10 +14,11 @@ The frontend server is a **thin proxy layer** — its only job is to authenticat
 
 SST provides seamless Next.js deployment via `sst.aws.Nextjs`. This means your Next.js app already has a server — use its API routes as the proxy layer. No extra infrastructure needed.
 
-Monorise Core creates both the `API_KEYS` allow-list and an `X_API_KEY` secret. Link `xApiKey` to the Next.js server so only your backend proxy can read the selected key:
+Monorise Core creates the `API_KEYS` allow-list. Create a separate `X_API_KEY` secret in your application and link it to the Next.js server so only your backend proxy can read the selected key:
 
 ```ts
-const { api, xApiKey } = new monorise.module.Core('core');
+const { api } = new monorise.module.Core('core');
+const xApiKey = new sst.Secret('X_API_KEY', 'secret1');
 
 new sst.aws.Nextjs('web', {
   link: [api, xApiKey],

--- a/www/docs/best-practices.md
+++ b/www/docs/best-practices.md
@@ -19,13 +19,12 @@ SST provides seamless Next.js deployment via `sst.aws.Nextjs`. This means your N
 ```ts
 // app/api/proxy-request.ts
 import { type NextRequest, NextResponse } from 'next/server';
-import { Resource } from 'sst';
 import { validateToken } from './validate-token';
 
 function rewriteUrl(requestUrl: string, replacePath?: string) {
   const path = replacePath
-    ?? requestUrl.replace(/^https?:\/\/[^\/]+(:d+)?\/api\//, '');
-  return `${Resource.CoreApi.url}/${path}`;
+    ?? requestUrl.replace(/^https?:\/\/[^\/]+\/api\//, '');
+  return `${process.env.API_BASE_URL}/${path}`;
 }
 
 export const proxyRequest = async ({
@@ -56,7 +55,7 @@ export const proxyRequest = async ({
     headers: {
       'content-type': 'application/json',
       'account-id': accountId,
-      'x-api-key': Resource.ApiKeys.value,
+      'x-api-key': process.env.API_KEY ?? '',
     },
     cache: 'no-store',
   });
@@ -80,10 +79,11 @@ export const DELETE = (req: NextRequest) => proxyRequest({ req });
 **3. Configure monorise/react** to point at your proxy:
 
 ```ts
-setMonoriseOptions({
-  entityApiBaseUrl: '/api/core/entity',
-  mutualApiBaseUrl: '/api/core/mutual',
-  tagApiBaseUrl: '/api/core/tag',
+Monorise.config({
+  entityConfig: EntityConfig,
+  entityBaseUrl: '/api/core/entity',
+  mutualBaseUrl: '/api/core/mutual',
+  tagBaseUrl: '/api/core/tag',
 });
 ```
 
@@ -114,20 +114,23 @@ Now all client-side hooks (`useEntities`, `useMutuals`, etc.) route through your
 
 Don't reuse the same API key across environments. Configure separate keys for development, staging, and production via the `API_KEYS` SST secret:
 
-`API_KEYS` is used by the monorise API Gateway to authenticate incoming requests. `X_API_KEY` is used by your proxy server to attach the key when forwarding requests to the API Gateway.
+`API_KEYS` is used by the monorise API Gateway to authenticate incoming requests. The generated proxy reads the singular `API_KEY` environment variable, configured on the `sst.aws.Nextjs` resource in `sst.config.ts`; its value must match one entry in `API_KEYS`.
 
 ```bash
 # API Gateway accepts these keys (array of valid keys)
 npx sst secret set API_KEYS '["dev-key-123"]' --stage dev
 npx sst secret set API_KEYS '["prod-key-abc"]' --stage production
+```
 
-# Proxy server uses this key to call the API Gateway
-npx sst secret set X_API_KEY 'dev-key-123' --stage dev
-npx sst secret set X_API_KEY 'prod-key-abc' --stage production
+```ts
+// In sst.config.ts, replace the generated default for each stage:
+environment: {
+  API_KEY: 'dev-key-123',
+}
 ```
 
 ::: tip
-`API_KEYS` is an array because you may have multiple valid keys (e.g., for key rotation). `X_API_KEY` is the single key your proxy uses — it must match one of the values in `API_KEYS`.
+`API_KEYS` is an array because you may have multiple valid keys (e.g., for key rotation). `API_KEY` is the single key your generated proxy uses — it must match one of the values in `API_KEYS`.
 :::
 
 ## Keep entity configs focused
@@ -141,9 +144,9 @@ monorise/configs/
   order.ts          ✓
 ```
 
-## Prefer direct mutuals over prejoins
+## Prefer direct mutuals over tree processors
 
-If you know the relationship at creation time, add a direct mutual field instead of using prejoins. Direct mutuals are cheaper (no write amplification) and simpler to reason about. See [Prejoins](/concepts/prejoins) for details.
+If you know the relationship at creation time, add a direct mutual field instead of using a tree processor. Direct mutuals are cheaper (no write amplification) and simpler to reason about. See [Tree Processors](/concepts/prejoins) for details.
 
 ## Use tags for access patterns, not data storage
 

--- a/www/docs/concepts/entities.md
+++ b/www/docs/concepts/entities.md
@@ -58,7 +58,71 @@ export default config;
 | `adjustmentConditions` | `object` | No | Named conditions for [`adjustEntity`](/react#adjustentity) — enforces preconditions on numeric adjustments |
 | `updateConditions` | `object` | No | Named conditions for [`editEntity`](/react#editentity) — enforces preconditions on updates |
 | `allowLegacyWhere` | `boolean` | No | Opt in to accepting raw `$where` on `editEntity` (deprecated, disabled by default — see [Conditional updates](/react#editentity)) |
+| `effect` | `function` | No | Applies a final Zod refinement to the merged entity schema |
 | `ttl` | `object` | No | DynamoDB TTL config — see [TTL](#ttl-time-to-live) below |
+
+## Conditional writes
+
+Conditions are named, server-owned preconditions. The client sends only a condition name; Monorise resolves the condition to a DynamoDB condition expression and enforces it atomically.
+
+```ts
+const config = createEntityConfig({
+  name: 'wallet',
+  displayName: 'Wallet',
+  baseSchema: z.object({
+    balance: z.number(),
+    status: z.enum(['pending', 'active', 'archived']),
+  }).partial(),
+  adjustmentConditions: {
+    withdraw: (_data, adjustments) => ({
+      balance: { $gte: Math.abs(adjustments.balance ?? 0) },
+    }),
+  },
+  updateConditions: {
+    activate: { status: { $eq: 'pending' } },
+    archive: (_data) => ({ status: { $ne: 'archived' } }),
+  },
+});
+```
+
+`adjustmentConditions` receives `(data, adjustments)` and requires every `adjustEntity` call to name a condition when the config is present:
+
+```ts
+await adjustEntity(Entity.WALLET, walletId, { balance: -500 }, {
+  condition: 'withdraw',
+});
+```
+
+`updateConditions` receives `(data)` and is optional for `editEntity` calls:
+
+```ts
+await editEntity(Entity.WALLET, walletId, {
+  status: 'active',
+  $condition: 'activate',
+});
+```
+
+If a named condition is unknown, or the entity has no matching condition config, the request is rejected. A condition that does not hold returns a conflict. Supported operators are `$eq`, `$ne`, `$gt`, `$lt`, `$gte`, `$lte`, `$exists`, and `$beginsWith`.
+
+::: warning Legacy conditions
+`adjustmentConstraints` and raw `$where` are deprecated compatibility mechanisms. `$where` is disabled by default; prefer named `adjustmentConditions` and `updateConditions` for all new code.
+:::
+
+## Advanced validation
+
+Use `effect` when validation depends on the final merged entity schema rather than one individual field:
+
+```ts
+const config = createEntityConfig({
+  name: 'invite',
+  displayName: 'Invite',
+  baseSchema,
+  effect: (schema) => schema.refine(
+    (data) => !data.expiresAt || !data.createdAt || data.expiresAt > data.createdAt,
+    'expiresAt must be after createdAt',
+  ),
+});
+```
 
 ## Unique fields
 
@@ -144,9 +208,9 @@ Internally, this always writes to an `expiresAt` attribute — the same attribut
 Multiple entity operations can be executed atomically using the [`transaction`](/react#transaction) API. All operations succeed or all fail — no partial writes.
 
 ```ts
-import { transaction, transactional } from 'monorise/react';
+import { coreService, transactional } from 'monorise/react';
 
-await transaction([
+await coreService.transaction([
   transactional.createEntity('order', { ... }),
   transactional.adjustEntity('wallet', '...', { balance: -100, $condition: 'withdraw' }),
 ]);

--- a/www/docs/concepts/index.md
+++ b/www/docs/concepts/index.md
@@ -16,4 +16,4 @@ This system revolves around three core building blocks:
 | [Mutual](/concepts/mutuals) | A relationship record between two entities that can hold data |
 | [Tag](/concepts/tags) | A key/value access pattern to quickly query subsets of entities |
 
-These are defined per entity in config files via `createEntityConfig` (Zod-based). Additionally, **Prejoins** are computed relationships that "join" through a chain of mutuals to avoid expensive multi-hop queries.
+These are defined per entity in config files via `createEntityConfig` (Zod-based). Additionally, **tree processors** traverse a chain of mutuals asynchronously and materialize derived relationships for direct reads. The current configuration key for a tree processor is `mutual.prejoins`.

--- a/www/docs/concepts/mutuals.md
+++ b/www/docs/concepts/mutuals.md
@@ -176,18 +176,7 @@ if (lastKey) {
 
 ### Creating mutuals
 
-When creating an entity, include the mutual field IDs to automatically create relationships:
-
-```ts
-// Creating a student enrolled in two courses
-await createEntity(Entity.STUDENT, {
-  name: 'Alice',
-  email: 'alice@school.com',
-  courseIds: [courseId1, courseId2],
-});
-```
-
-Or create a mutual relationship directly:
+Create a mutual relationship directly with data that satisfies its shared config:
 
 ```ts
 await createMutual(
@@ -195,9 +184,11 @@ await createMutual(
   Entity.COURSE,
   studentId,
   courseId,
-  { grade: 'A', enrolledAt: new Date().toISOString() }, // mutual data
+  { role: 'student', enrolledAt: new Date().toISOString() }, // mutual data
 );
 ```
+
+Because `enrollmentMutual` requires both fields, the call must provide both. Entity create and update operations can also create mutuals from fields such as `courseIds`. If the shared schema requires `mutualData`, use [`toMutualIds` with a `mutualDataProcessor`](#using-tomutualids-with-validated-data) so those writes produce valid relationship data.
 
 ## Mutual data
 
@@ -218,78 +209,7 @@ Each mutual object returned by hooks contains:
 }
 ```
 
-## Validating mutual data with `createMutualConfig`
-
-By default, `mutualData` accepts any shape — there's no validation. Use `createMutualConfig` to define a schema that validates mutual data on create and update operations.
-
-### Defining a mutual config
-
-Since a mutual relationship is shared between two entities, define the config **once** and reference it from both sides:
-
-```ts
-import { createMutualConfig } from 'monorise/base';
-
-// Define once
-const enrollmentMutual = createMutualConfig({
-  entities: [Entity.STUDENT, Entity.COURSE],
-  mutualDataSchema: z.object({
-    role: z.enum(['student', 'auditor']),
-    enrolledAt: z.string().datetime(),
-  }),
-});
-```
-
-### Referencing from entity configs
-
-Pass the mutual config to the `mutual` property in `mutualFields`:
-
-**Student config:**
-
-```ts
-const config = createEntityConfig({
-  name: 'student',
-  displayName: 'Student',
-  baseSchema,
-  mutual: {
-    mutualSchema: z
-      .object({
-        courseIds: z.string().array(),
-      })
-      .partial(),
-    mutualFields: {
-      courseIds: {
-        entityType: Entity.COURSE,
-        mutual: enrollmentMutual,
-      },
-    },
-  },
-});
-```
-
-**Course config:**
-
-```ts
-const config = createEntityConfig({
-  name: 'course',
-  displayName: 'Course',
-  baseSchema,
-  mutual: {
-    mutualSchema: z
-      .object({
-        studentIds: z.string().array(),
-      })
-      .partial(),
-    mutualFields: {
-      studentIds: {
-        entityType: Entity.STUDENT,
-        mutual: enrollmentMutual,
-      },
-    },
-  },
-});
-```
-
-### What gets validated
+## Mutual data validation
 
 When `mutualDataSchema` is defined, it validates:
 
@@ -299,9 +219,7 @@ When `mutualDataSchema` is defined, it validates:
 
 Invalid payloads will throw a Zod validation error.
 
-::: tip
-`createMutualConfig` is optional. Existing configs without it continue to work as before — any data shape is accepted.
-:::
+Without `createMutualConfig`, existing relationships continue to accept any `mutualData` shape for backward compatibility.
 
 ## Using `toMutualIds` with validated data
 

--- a/www/docs/concepts/mutuals.md
+++ b/www/docs/concepts/mutuals.md
@@ -28,7 +28,26 @@ Now `Enrollment` becomes a **mutual**, holding data about the relationship. Late
 
 ## Defining mutuals
 
-Mutuals are configured within an entity's config. You need to define both sides — the student knows about courses, and the course knows about students:
+For new projects, define relationship data once with `createMutualConfig` and reference that config from both entity sides. This gives `mutualData` one Zod schema for direct creates, updates, and processor output.
+
+`mutualSchema` and `mutualDataSchema` validate different inputs:
+
+```text
+student.courseIds / course.studentIds  -> entity input fields
+enrollmentMutual.mutualDataSchema      -> data stored on the relationship
+```
+
+```ts
+import { createEntityConfig, createMutualConfig } from 'monorise/base';
+
+const enrollmentMutual = createMutualConfig({
+  entities: [Entity.STUDENT, Entity.COURSE],
+  mutualDataSchema: z.object({
+    role: z.enum(['student', 'auditor']),
+    enrolledAt: z.string().datetime(),
+  }),
+});
+```
 
 **Student config:**
 
@@ -38,14 +57,13 @@ const config = createEntityConfig({
   displayName: 'Student',
   baseSchema,
   mutual: {
-    mutualSchema: z
-      .object({
-        courseIds: z.string().array(),
-      })
-      .partial(),
+    mutualSchema: z.object({
+      courseIds: z.string().array(),
+    }).partial(),
     mutualFields: {
       courseIds: {
         entityType: Entity.COURSE,
+        mutual: enrollmentMutual,
       },
     },
   },
@@ -60,21 +78,22 @@ const config = createEntityConfig({
   displayName: 'Course',
   baseSchema,
   mutual: {
-    mutualSchema: z
-      .object({
-        studentIds: z.string().array(),
-      })
-      .partial(),
+    mutualSchema: z.object({
+      studentIds: z.string().array(),
+    }).partial(),
     mutualFields: {
       studentIds: {
         entityType: Entity.STUDENT,
+        mutual: enrollmentMutual,
       },
     },
   },
 });
 ```
 
-When you create a student with `courseIds: ['course-1', 'course-2']`, monorise automatically creates the mutual records in **both directions**.
+::: tip Backward compatibility
+`createMutualConfig` was introduced after mutuals existed, so it remains optional. Existing inline mutual configurations continue to work and accept unvalidated `mutualData`. For new relationships that carry data, use a shared config from the start.
+:::
 
 ## Querying mutuals (API)
 
@@ -284,7 +303,7 @@ Invalid payloads will throw a Zod validation error.
 `createMutualConfig` is optional. Existing configs without it continue to work as before — any data shape is accepted.
 :::
 
-## Advanced: `toMutualIds`
+## Using `toMutualIds` with validated data
 
 By default, each field in `mutualSchema` is expected to be a plain array of entity IDs:
 
@@ -310,7 +329,21 @@ mutual: {
   mutualFields: {
     enrollments: {
       entityType: Entity.COURSE,
+      mutual: enrollmentMutual,
       toMutualIds: (payload) => payload.map((e) => e.courseId),
+      mutualDataProcessor: (_mutualIds, currentMutual, customContext) => {
+        const enrollments = customContext as Array<{
+          courseId: string;
+          role: 'student' | 'auditor';
+        }>;
+        const enrollment = enrollments?.find(
+          (item) => item.courseId === currentMutual.entityId,
+        );
+        return {
+          role: enrollment?.role ?? 'student',
+          enrolledAt: new Date().toISOString(),
+        };
+      },
     },
   },
 },
@@ -328,7 +361,7 @@ await createEntity(Entity.STUDENT, {
 });
 ```
 
-Monorise calls `toMutualIds(payload)` to get `['course-1', 'course-2']` and creates the mutual records. The original payload is forwarded as `customContext` to `mutualDataProcessor` (see below), so you can use it to store per-relationship data.
+Monorise calls `toMutualIds(payload)` to get `['course-1', 'course-2']` and creates the mutual records. The original payload is forwarded to `mutualDataProcessor`, which returns data accepted by `enrollmentMutual.mutualDataSchema`.
 
 ## Advanced: `mutualDataProcessor`
 

--- a/www/docs/concepts/prejoins.md
+++ b/www/docs/concepts/prejoins.md
@@ -1,43 +1,99 @@
 # Tree Processors
 
-A **tree processor** is an event-driven traversal of mutual relationships. It materializes a derived direct mutual so a multi-hop relationship can be read with one query.
+A **tree processor** computes a relationship by traversing a chain of mutuals, avoiding expensive multi-hop queries at read time. Instead of querying A → B → C at runtime, Monorise computes the A → C relationship and stores it as a mutual.
 
-The configuration key is currently `mutual.prejoins` for compatibility. Older documentation and runtime names may call this feature a *prejoin*.
-
-```text
-Teacher -> Class -> Student
-   |                    ^
-   +-- tree processor --+
-
-Stored result: Teacher -> Student
-```
-
-::: warning Write-heavy
-Tree processors trade read latency for asynchronous write work. Every source relationship change can traverse the configured path and update derived mutuals. Use one only after a direct mutual is not possible and multi-hop reads are a demonstrated bottleneck.
+::: info Configuration name
+Tree processors were previously described as prejoins. The public configuration key remains `mutual.prejoins` for backward compatibility.
 :::
 
-## Choose a direct relationship first
+::: warning Write-heavy
+Tree processors are **write-heavy** — when a subscribed relationship changes, the tree processor recomputes the derived relationship. In most cases, you do **not** need a tree processor. Only use one when you have a proven need to eliminate multi-hop reads.
+:::
 
-If you know a relationship at creation time, model it directly instead of deriving it. For example, if every `Member` already knows its tenant, store `tenantIds` alongside `organisationIds` and query `Tenant -> Member` directly.
+## When to use tree processors
+
+Use tree processors when:
+- You have a **chain of mutual relationships** (A → B → C) and frequently query A → C directly
+- The **read frequency far exceeds change frequency** for the subscribed relationships
+- The alternative (multiple sequential API calls) creates unacceptable latency
+
+Do **not** use tree processors when:
+- You can tolerate two sequential API calls
+- The intermediate relationships change frequently (high write amplification)
+- The relationship is already direct (a single `useMutuals` call is sufficient)
+- You can add a **direct mutual field** instead (see below)
+
+## Alternative: direct mutual fields
+
+Before reaching for a tree processor, consider whether you can simply add a direct mutual relationship. This is often the simpler and more efficient solution.
+
+**Example:** You have three entities — `Tenant`, `Organisation`, and `Member`. A tenant has organisations, and organisations have members. You need to list all members by tenant.
+
+**Without a direct mutual**, you'd need two calls:
+1. Get all organisations for the tenant
+2. For each organisation, get all members
+
+**With a tree processor**, Monorise would compute `Tenant → Member` automatically — but this adds write overhead every time a subscribed relationship changes.
+
+**Better approach:** Add `tenantIds` as a mutual field directly on `Member`:
 
 ```ts
-mutual: {
-  mutualSchema: z.object({
-    organisationIds: z.string().array(),
-    tenantIds: z.string().array(),
-  }).partial(),
-  mutualFields: {
-    organisationIds: { entityType: Entity.ORGANISATION },
-    tenantIds: { entityType: Entity.TENANT },
+const config = createEntityConfig({
+  name: 'member',
+  displayName: 'Member',
+  baseSchema,
+  mutual: {
+    mutualSchema: z
+      .object({
+        organisationIds: z.string().array(),
+        tenantIds: z.string().array(), // direct link to tenant
+      })
+      .partial(),
+    mutualFields: {
+      organisationIds: { entityType: Entity.ORGANISATION },
+      tenantIds: { entityType: Entity.TENANT },
+    },
   },
-},
+});
 ```
 
-Use a tree processor only when the final relationship emerges from other relationships, such as students being assigned to classes and classes being assigned to teachers.
+When creating a member, pass both IDs:
 
-## Configure a tree processor
+```ts
+await createEntity(Entity.MEMBER, {
+  name: 'Alice',
+  organisationIds: [organisationId],
+  tenantIds: [tenantId],
+});
+```
 
-This configuration derives `Teacher -> Student` from `Teacher -> Class -> Student`:
+Now you can query directly in a single call:
+
+```ts
+// All members for a tenant — no tree processor needed
+const { mutuals: members } = useMutuals(Entity.TENANT, Entity.MEMBER, tenantId);
+```
+
+::: tip
+If you know the relationship at creation time, a direct mutual field is always cheaper and simpler than a tree processor. Reserve tree processors for relationships that are truly derived and cannot be known upfront.
+:::
+
+## When tree processors are necessary
+
+Tree processors are the right choice when the A → C relationship **cannot be established at creation time** — it only emerges from the chain of intermediate relationships. For example, if students are assigned to classes, and classes are assigned to teachers, the teacher-student relationship is purely derived.
+
+## Example
+
+Imagine a school system where:
+
+- `Teacher` has a mutual with `Class`
+- `Class` has a mutual with `Student`
+
+To show all students for a teacher, you'd normally need two queries:
+1. Get all classes for the teacher
+2. For each class, get all students
+
+With a tree processor, Monorise computes the `Teacher → Student` relationship:
 
 ```ts
 const config = createEntityConfig({
@@ -45,13 +101,15 @@ const config = createEntityConfig({
   displayName: 'Teacher',
   baseSchema,
   mutual: {
-    // Run when the Teacher -> Class relationship changes.
+    // Trigger this tree when the Teacher → Class relationship changes.
     subscribes: [{ entityType: Entity.CLASS }],
     mutualSchema: z.object({
       classIds: z.string().array(),
     }).partial(),
     mutualFields: {
-      classIds: { entityType: Entity.CLASS },
+      classIds: {
+        entityType: Entity.CLASS,
+      },
     },
     // `prejoins` remains the public configuration key.
     prejoins: [
@@ -59,7 +117,7 @@ const config = createEntityConfig({
         mutualField: 'classIds',
         targetEntityType: Entity.STUDENT,
         entityPaths: [
-          // The source is included first; it is already cached by the processor.
+          // Start with the source entity, then describe each traversal step.
           { entityType: Entity.TEACHER },
           { entityType: Entity.CLASS },
           { entityType: Entity.STUDENT },
@@ -70,34 +128,50 @@ const config = createEntityConfig({
 });
 ```
 
-The processor:
+### How it works
 
-1. Receives the `Teacher -> Class` relationship update.
-2. Traverses the path from the cached teacher through classes to students.
-3. Publishes an update for the derived `Teacher -> Student` mutual.
-4. Materializes that mutual asynchronously, so `useMutuals(Entity.TEACHER, Entity.STUDENT, teacherId)` becomes a direct read.
+1. When a `Teacher → Class` mutual changes, the tree processor is triggered
+2. The processor walks the configured path: `Teacher → Class → Student`
+3. It publishes derived mutual events for `Teacher → Student`
+4. These are processed as regular mutual records in DynamoDB
 
-### Path processors and cache control
+Now you can query `useMutuals(Entity.TEACHER, Entity.STUDENT, teacherId)` in a single call.
 
-Each path step can filter or transform the mutuals discovered at that step:
+### Custom processors
+
+Each entity path in a tree processor can have a custom `processor` function:
 
 ```ts
-{
-  entityType: Entity.STUDENT,
-  processor: (items, context) => ({
-    items: items.filter((item) => item.data.isActive),
-    context,
-  }),
-}
+prejoins: [
+  {
+    mutualField: 'classIds',
+    targetEntityType: Entity.STUDENT,
+    entityPaths: [
+      { entityType: Entity.TEACHER },
+      { entityType: Entity.CLASS },
+      {
+        entityType: Entity.STUDENT,
+        processor: (items, context) => {
+          // Filter or transform the joined items
+          return {
+            items: items.filter(item => item.mutualData.isActive),
+            context,
+          };
+        },
+      },
+    ],
+  },
+],
 ```
 
-By default, a tree processor reuses a relationship type it has already traversed during that invocation. Set `skipCache: true` on a path step only when the traversal must revisit that type. It does not change EventBridge/SQS delivery or make the derived relationship real-time.
+By default, a tree processor reuses an entity type already traversed during the same invocation. Set `skipCache: true` on a path only when that type must be traversed again. It does not make asynchronous processing real-time.
 
 ## Trade-offs
 
-| Aspect | Direct mutual | Tree processor |
-|--------|---------------|----------------|
-| Read path | One mutual query | One mutual query after materialization |
-| Write cost | Low | Higher due to traversal and derived writes |
-| Freshness | Direct relationship state | Eventually consistent derived state |
-| Use when | Relationship is known at write time | Relationship is genuinely derived |
+| Aspect | Without tree processors | With tree processors |
+|--------|-------------------------|----------------------|
+| Read latency | Multiple sequential calls | Single call |
+| Write cost | Low | High (recomputation on subscribed relationship changes) |
+| Data freshness | No additional derived projection | Eventually consistent derived projection |
+| Complexity | Simple | More moving parts |
+| DynamoDB cost | Higher read capacity | Higher write capacity |

--- a/www/docs/concepts/prejoins.md
+++ b/www/docs/concepts/prejoins.md
@@ -1,95 +1,43 @@
-# Prejoins
+# Tree Processors
 
-A **prejoin** is a computed relationship that "joins" through a chain of mutuals to avoid expensive multi-hop queries at read time. Instead of querying A → B → C at runtime, monorise precomputes the A → C relationship and stores it as a mutual.
+A **tree processor** is an event-driven traversal of mutual relationships. It materializes a derived direct mutual so a multi-hop relationship can be read with one query.
+
+The configuration key is currently `mutual.prejoins` for compatibility. Older documentation and runtime names may call this feature a *prejoin*.
+
+```text
+Teacher -> Class -> Student
+   |                    ^
+   +-- tree processor --+
+
+Stored result: Teacher -> Student
+```
 
 ::: warning Write-heavy
-Prejoins are **write-heavy** — every time an intermediate entity changes, the prejoin processor must recompute the derived relationship. In most cases, you do **not** need prejoins. Only use them when you have a proven need to eliminate multi-hop reads.
+Tree processors trade read latency for asynchronous write work. Every source relationship change can traverse the configured path and update derived mutuals. Use one only after a direct mutual is not possible and multi-hop reads are a demonstrated bottleneck.
 :::
 
-## When to use prejoins
+## Choose a direct relationship first
 
-Use prejoins when:
-- You have a **chain of mutual relationships** (A → B → C) and frequently query A → C directly
-- The **read frequency far exceeds write frequency** for the intermediate entities
-- The alternative (multiple sequential API calls) creates unacceptable latency
-
-Do **not** use prejoins when:
-- You can tolerate two sequential API calls
-- The intermediate entities change frequently (high write amplification)
-- The chain is only two hops (a single `useMutuals` call is sufficient)
-- You can add a **direct mutual field** instead (see below)
-
-## Alternative: direct mutual fields
-
-Before reaching for prejoins, consider whether you can simply add a direct mutual relationship. This is often the simpler and more efficient solution.
-
-**Example:** You have three entities — `Tenant`, `Organisation`, and `Member`. A tenant has organisations, and organisations have members. You need to list all members by tenant.
-
-**Without a direct mutual**, you'd need two calls:
-1. Get all organisations for the tenant
-2. For each organisation, get all members
-
-**With prejoins**, monorise would compute `Tenant → Member` automatically — but this adds write overhead every time an organisation or member changes.
-
-**Better approach:** Add `tenantIds` as a mutual field directly on `Member`:
+If you know a relationship at creation time, model it directly instead of deriving it. For example, if every `Member` already knows its tenant, store `tenantIds` alongside `organisationIds` and query `Tenant -> Member` directly.
 
 ```ts
-const config = createEntityConfig({
-  name: 'member',
-  displayName: 'Member',
-  baseSchema,
-  mutual: {
-    mutualSchema: z
-      .object({
-        organisationIds: z.string().array(),
-        tenantIds: z.string().array(), // direct link to tenant
-      })
-      .partial(),
-    mutualFields: {
-      organisationIds: { entityType: Entity.ORGANISATION },
-      tenantIds: { entityType: Entity.TENANT },
-    },
+mutual: {
+  mutualSchema: z.object({
+    organisationIds: z.string().array(),
+    tenantIds: z.string().array(),
+  }).partial(),
+  mutualFields: {
+    organisationIds: { entityType: Entity.ORGANISATION },
+    tenantIds: { entityType: Entity.TENANT },
   },
-});
+},
 ```
 
-When creating a member, pass both IDs:
+Use a tree processor only when the final relationship emerges from other relationships, such as students being assigned to classes and classes being assigned to teachers.
 
-```ts
-await createEntity(Entity.MEMBER, {
-  name: 'Alice',
-  organisationIds: [organisationId],
-  tenantIds: [tenantId],
-});
-```
+## Configure a tree processor
 
-Now you can query directly in a single call:
-
-```ts
-// All members for a tenant — no prejoins needed
-const { mutuals: members } = useMutuals(Entity.TENANT, Entity.MEMBER, tenantId);
-```
-
-::: tip
-If you know the relationship at creation time, a direct mutual field is always cheaper and simpler than a prejoin. Reserve prejoins for cases where the relationship is truly derived and cannot be known upfront.
-:::
-
-## When prejoins are necessary
-
-Prejoins are the right choice when the A → C relationship **cannot be established at creation time** — it only emerges from the chain of intermediate relationships. For example, if members are assigned to classes, and classes are assigned to teachers, the teacher-member relationship is purely derived.
-
-## Example
-
-Imagine a school system where:
-
-- `Teacher` has a mutual with `Class`
-- `Class` has a mutual with `Student`
-
-To show all students for a teacher, you'd normally need two queries:
-1. Get all classes for the teacher
-2. For each class, get all students
-
-With a prejoin, monorise precomputes the `Teacher → Student` relationship:
+This configuration derives `Teacher -> Student` from `Teacher -> Class -> Student`:
 
 ```ts
 const config = createEntityConfig({
@@ -97,24 +45,24 @@ const config = createEntityConfig({
   displayName: 'Teacher',
   baseSchema,
   mutual: {
+    // Run when the Teacher -> Class relationship changes.
+    subscribes: [{ entityType: Entity.CLASS }],
     mutualSchema: z.object({
       classIds: z.string().array(),
     }).partial(),
     mutualFields: {
-      classIds: {
-        entityType: Entity.CLASS,
-      },
+      classIds: { entityType: Entity.CLASS },
     },
+    // `prejoins` remains the public configuration key.
     prejoins: [
       {
         mutualField: 'classIds',
         targetEntityType: Entity.STUDENT,
         entityPaths: [
-          {
-            entityType: Entity.STUDENT,
-            // optional: skipCache for real-time accuracy
-            // skipCache: true,
-          },
+          // The source is included first; it is already cached by the processor.
+          { entityType: Entity.TEACHER },
+          { entityType: Entity.CLASS },
+          { entityType: Entity.STUDENT },
         ],
       },
     ],
@@ -122,46 +70,34 @@ const config = createEntityConfig({
 });
 ```
 
-### How it works
+The processor:
 
-1. When a `Teacher → Class` mutual changes, the prejoin processor is triggered
-2. The processor walks the configured path: `Class → Student`
-3. It publishes derived mutual events for `Teacher → Student`
-4. These are processed as regular mutual records in DynamoDB
+1. Receives the `Teacher -> Class` relationship update.
+2. Traverses the path from the cached teacher through classes to students.
+3. Publishes an update for the derived `Teacher -> Student` mutual.
+4. Materializes that mutual asynchronously, so `useMutuals(Entity.TEACHER, Entity.STUDENT, teacherId)` becomes a direct read.
 
-Now you can query `useMutuals(Entity.TEACHER, Entity.STUDENT, teacherId)` in a single call.
+### Path processors and cache control
 
-### Custom processors
-
-Each entity path in a prejoin can have a custom `processor` function:
+Each path step can filter or transform the mutuals discovered at that step:
 
 ```ts
-prejoins: [
-  {
-    mutualField: 'classIds',
-    targetEntityType: Entity.STUDENT,
-    entityPaths: [
-      {
-        entityType: Entity.STUDENT,
-        processor: (items, context) => {
-          // Filter or transform the joined items
-          return {
-            items: items.filter(item => item.data.isActive),
-            context,
-          };
-        },
-      },
-    ],
-  },
-],
+{
+  entityType: Entity.STUDENT,
+  processor: (items, context) => ({
+    items: items.filter((item) => item.data.isActive),
+    context,
+  }),
+}
 ```
+
+By default, a tree processor reuses a relationship type it has already traversed during that invocation. Set `skipCache: true` on a path step only when the traversal must revisit that type. It does not change EventBridge/SQS delivery or make the derived relationship real-time.
 
 ## Trade-offs
 
-| Aspect | Without prejoins | With prejoins |
-|--------|-----------------|---------------|
-| Read latency | Multiple sequential calls | Single call |
-| Write cost | Low | High (recomputation on every change) |
-| Data freshness | Always current | Eventually consistent |
-| Complexity | Simple | More moving parts |
-| DynamoDB cost | Higher read capacity | Higher write capacity |
+| Aspect | Direct mutual | Tree processor |
+|--------|---------------|----------------|
+| Read path | One mutual query | One mutual query after materialization |
+| Write cost | Low | Higher due to traversal and derived writes |
+| Freshness | Direct relationship state | Eventually consistent derived state |
+| Use when | Relationship is known at write time | Relationship is genuinely derived |

--- a/www/docs/concepts/tags.md
+++ b/www/docs/concepts/tags.md
@@ -115,7 +115,7 @@ GET /core/tag/:entityType/:tagName?group=...&query=...&start=...&end=...&limit=.
 | Parameter | Description |
 |-----------|-------------|
 | `group` | Filter by group value |
-| `query` | Prefix filter for the sort value; cannot be combined with `start` or `end` |
+| `query` | Match one exact sort value; cannot be combined with `start` or `end` |
 | `start` | Sort value range start (inclusive) |
 | `end` | Sort value upper bound; the current key encoding excludes an exact matching sort value |
 | `limit` | Max results per page |
@@ -192,7 +192,7 @@ if (lastKey) {
 ```
 
 ::: tip React hook limitation
-The raw API supports group, prefix, and range queries. `useTaggedEntities` requires at least one `params` filter for its initial fetch, and its current `refetch` and `listMore` helpers require `params.group`. Use the raw API through a custom request when paginating an ungrouped range or prefix query.
+The raw API supports group, exact sort-value, and range queries. `useTaggedEntities` requires at least one `params` filter for its initial fetch, and its current `refetch` and `listMore` helpers require `params.group`. Use the raw API through a custom request when paginating an ungrouped range or exact-value query.
 :::
 
 ## Data layout

--- a/www/docs/concepts/tags.md
+++ b/www/docs/concepts/tags.md
@@ -109,15 +109,19 @@ tags: [
 ## Querying tags (API)
 
 ```
-GET /core/tag/:entityType/:tagName?group=...&start=...&end=...
+GET /core/tag/:entityType/:tagName?group=...&query=...&start=...&end=...&limit=...&lastKey=...
 ```
 
 | Parameter | Description |
 |-----------|-------------|
 | `group` | Filter by group value |
+| `query` | Prefix filter for the sort value; cannot be combined with `start` or `end` |
 | `start` | Sort value range start (inclusive) |
-| `end` | Sort value range end (inclusive) |
+| `end` | Sort value upper bound; the current key encoding excludes an exact matching sort value |
 | `limit` | Max results per page |
+| `lastKey` | Opaque cursor returned by the previous page |
+
+Results are ordered by tag sort key in descending order. The response contains `entities`, `totalCount`, and `lastKey` when another page is available.
 
 Examples:
 
@@ -125,11 +129,14 @@ Examples:
 # All organisations of type "club"
 GET /core/tag/organisation/type?group=club
 
-# All organisations created in 2025
-GET /core/tag/organisation/created?start=2025-01-01&end=2025-12-31
+# All organisations created in 2025; use the next boundary as the end value
+GET /core/tag/organisation/created?start=2025-01-01&end=2026-01-01
 
 # Organisations in eu-west-1, activated after 2025-01-01
 GET /core/tag/organisation/region-activation?group=eu-west-1&start=2025-01-01
+
+# Continue a paginated query
+GET /core/tag/organisation/type?group=club&limit=20&lastKey=<cursor>
 ```
 
 ## Querying tags (React)
@@ -154,7 +161,7 @@ const { entities, isLoading } = useTaggedEntities(
 const { entities } = useTaggedEntities(
   Entity.ORGANISATION,
   'created',
-  { params: { start: '2025-01-01', end: '2025-12-31' } },
+  { params: { start: '2025-01-01', end: '2026-01-01' } },
 );
 ```
 
@@ -183,6 +190,10 @@ if (lastKey) {
   await listMore();
 }
 ```
+
+::: tip React hook limitation
+The raw API supports group, prefix, and range queries. `useTaggedEntities` requires at least one `params` filter for its initial fetch, and its current `refetch` and `listMore` helpers require `params.group`. Use the raw API through a custom request when paginating an ungrouped range or prefix query.
+:::
 
 ## Data layout
 

--- a/www/docs/contributing.md
+++ b/www/docs/contributing.md
@@ -85,4 +85,3 @@ npm test
 Feel free to join our [Discord](https://discord.gg/9c3ccQkvGj) for discussion or create an issue if you’re stuck!
 
 Thanks again! You’re awesome. 💙
-```

--- a/www/docs/deploying.md
+++ b/www/docs/deploying.md
@@ -28,9 +28,8 @@ Before your first deployment to a shared environment, set the API key secrets:
 npx sst secret set API_KEYS '["your-secure-key-here"]' --stage dev
 npx sst secret set API_KEYS '["your-secure-key-here"]' --stage production
 
-# Proxy server uses this key to call the API Gateway
-npx sst secret set X_API_KEY 'your-secure-key-here' --stage dev
-npx sst secret set X_API_KEY 'your-secure-key-here' --stage production
+# Update the generated `API_KEY` environment value in sst.config.ts to one
+# of the accepted API_KEYS values for each deployed stage.
 ```
 
 ::: danger
@@ -46,10 +45,12 @@ The default API keys (`secret1`, `secret2`) are public knowledge. Anyone who kno
    npx sst secret set API_KEYS '["old-key", "new-key"]' --stage production
    ```
 
-2. **Update your proxy** to use the new key:
-   ```bash
-   npx sst secret set X_API_KEY 'new-key' --stage production
-   ```
+2. **Update your proxy** to use the new key by replacing `API_KEY` in the generated `sst.aws.Nextjs` environment:
+    ```ts
+    environment: {
+      API_KEY: 'new-key',
+    }
+    ```
 
 3. **Remove the old key** once all services have switched:
    ```bash

--- a/www/docs/deploying.md
+++ b/www/docs/deploying.md
@@ -49,9 +49,9 @@ The default API keys (`secret1`, `secret2`) are public knowledge. Anyone who kno
    ```
 
 2. **Switch the backend proxy** to the new key:
-    ```bash
-    npx sst secret set X_API_KEY 'new-key' --stage production
-    ```
+   ```bash
+   npx sst secret set X_API_KEY 'new-key' --stage production
+   ```
 
 3. **Remove the old key** once all services have switched:
    ```bash

--- a/www/docs/deploying.md
+++ b/www/docs/deploying.md
@@ -28,9 +28,12 @@ Before your first deployment to a shared environment, set the API key secrets:
 npx sst secret set API_KEYS '["your-secure-key-here"]' --stage dev
 npx sst secret set API_KEYS '["your-secure-key-here"]' --stage production
 
-# Update the generated `API_KEY` environment value in sst.config.ts to one
-# of the accepted API_KEYS values for each deployed stage.
+# Backend proxy attaches this selected key to each Core API request
+npx sst secret set X_API_KEY 'your-secure-key-here' --stage dev
+npx sst secret set X_API_KEY 'your-secure-key-here' --stage production
 ```
+
+`API_KEYS` is the rotatable allow-list used by Monorise Core to verify requests. `X_API_KEY` is one selected key held by your backend proxy and attached to requests as the `x-api-key` header. It must match one entry in `API_KEYS`.
 
 ::: danger
 The default API keys (`secret1`, `secret2`) are public knowledge. Anyone who knows them can read and write to your database. Always set strong, unique keys for dev and production.
@@ -45,11 +48,9 @@ The default API keys (`secret1`, `secret2`) are public knowledge. Anyone who kno
    npx sst secret set API_KEYS '["old-key", "new-key"]' --stage production
    ```
 
-2. **Update your proxy** to use the new key by replacing `API_KEY` in the generated `sst.aws.Nextjs` environment:
-    ```ts
-    environment: {
-      API_KEY: 'new-key',
-    }
+2. **Switch the backend proxy** to the new key:
+    ```bash
+    npx sst secret set X_API_KEY 'new-key' --stage production
     ```
 
 3. **Remove the old key** once all services have switched:
@@ -70,4 +71,4 @@ npx sst deploy --stage staging    # staging environment
 npx sst deploy --stage production # production environment
 ```
 
-Each stage has its own secrets, so API keys are never shared across environments.
+Each stage has its own `API_KEYS` allow-list and `X_API_KEY` proxy secret, so keys are not shared across environments.

--- a/www/docs/faq.md
+++ b/www/docs/faq.md
@@ -55,13 +55,13 @@ Monorise uses **eventual consistency** for denormalized data:
 
 1. When you create/update an entity, the API writes to DynamoDB immediately (strongly consistent)
 2. Events are published to EventBridge, which triggers processors via SQS
-3. Processors update related records (mutuals, tags, prejoins, replicas) asynchronously
+3. Processors update related records (mutuals, tags, derived tree relationships, replicas) asynchronously
 
 In practice, propagation happens within milliseconds to seconds. The React SDK's optimistic updates make the UI feel instant regardless.
 
 ## What happens if a processor fails?
 
-Failed processor messages are sent to a **Dead Letter Queue (DLQ)**. Monorise creates an SNS alarm topic so you can be notified of failures. If you configure a `slackWebhook` in `MonoriseCore`, you'll get Slack alerts automatically.
+Failed processor messages are sent to a **Dead Letter Queue (DLQ)**. Monorise creates an SNS alarm topic so you can attach your preferred notification integration.
 
 Failed messages can be replayed from the DLQ once the issue is resolved.
 

--- a/www/docs/getting-started.md
+++ b/www/docs/getting-started.md
@@ -74,7 +74,7 @@ cd my-app
 npx sst dev
 ```
 
-That's it! Open http://localhost:3000 to see the example app.
+That's it! Open `http://localhost:3000` to see the example app.
 
 ## Understanding the structure
 
@@ -286,7 +286,6 @@ The `monorise.module.Core` construct provisions everything you need — API Gate
 new monorise.module.Core('core', {
   allowOrigins: ['https://myapp.com'],   // CORS origins
   allowHeaders: ['x-custom-header'],     // Additional CORS headers
-  slackWebhook: 'https://hooks...',      // Slack alerts for processor errors
   configRoot: './services/api',          // Custom config root path
   cloudwatchLogRetention: '1 week',      // Lambda log retention period
   cloudwatchDashboard: { enabled: $app.stage === 'production' },  // Dashboard only on prod

--- a/www/docs/index.md
+++ b/www/docs/index.md
@@ -75,7 +75,7 @@ export default createEntityConfig({
 
 ```tsx [app/members/page.tsx]
 import { useEntities, createEntity } from 'monorise/react';
-import { Entity } from '#/monorise/entities';
+import { Entity } from '#/monorise';
 
 export default function MembersPage() {
   const { entities: members, searchField, isLoading } = useEntities(Entity.MEMBER);
@@ -124,7 +124,7 @@ That's it — API, DynamoDB, EventBridge, processors, and a type-safe frontend. 
   </div>
   <div class="feature">
     <h3><span class="feature-icon">&#x1F4E6;</span> Full-Stack SDK</h3>
-    <p>Backend API (Hono), React hooks with caching, SST v3 infrastructure module — one package covers the entire stack.</p>
+    <p>Backend API (Hono), React hooks with caching, SST v4 infrastructure module — one package covers the entire stack.</p>
   </div>
   <div class="feature">
     <h3><span class="feature-icon">&#x1F6E0;&#xFE0F;</span> Seamless Dev Workflow</h3>

--- a/www/docs/packages.md
+++ b/www/docs/packages.md
@@ -14,7 +14,7 @@ Import from subpaths:
 import { createEntityConfig } from 'monorise/base';
 import { useEntities, useMutuals } from 'monorise/react';
 import { CoreFactory } from 'monorise/core';
-import { MonoriseCore } from 'monorise/sst';
+const { monorise } = await import('monorise/sst');
 ```
 
 ## Individual packages
@@ -25,7 +25,7 @@ import { MonoriseCore } from 'monorise/sst';
 | `@monorise/core` | Hono API, DynamoDB repositories, processors, event utils | `npm i @monorise/core` |
 | `@monorise/cli` | Generates `.monorise/config.ts` + `.monorise/handle.ts` | `npm i @monorise/cli` |
 | `@monorise/react` | Client SDK — hooks, stores, axios helpers | `npm i @monorise/react` |
-| `@monorise/sst` | SST v3 module — API, bus, table, queues, processors | `npm i @monorise/sst` |
+| `@monorise/sst` | SST v4 module — API, bus, table, queues, processors | `npm i @monorise/sst` |
 
 ## `monorise/base`
 
@@ -36,7 +36,7 @@ The foundation package. Exports `createEntityConfig`, `Entity` enum, `EntitySche
 The backend runtime. Provides:
 - **Hono API handlers** for entity, mutual, and tag CRUD
 - **DynamoDB repositories** for single-table access patterns
-- **Processors** (mutual, tag, prejoin, replication) for keeping denormalized data in sync
+- **Processors** (mutual, tag, tree, replication) for keeping denormalized data in sync
 - **Event utilities** for EventBridge integration
 
 ## `monorise/cli`
@@ -55,7 +55,7 @@ The frontend SDK for React applications. Provides:
 
 ## `monorise/sst`
 
-The SST v3 infrastructure module. Creates:
+The SST v4 infrastructure module. Creates:
 - API Gateway + Lambda (Hono)
 - DynamoDB single table with indexes
 - EventBridge bus
@@ -67,7 +67,7 @@ The SST v3 infrastructure module. Creates:
 | Area | Path |
 |------|------|
 | Core API + processors | `packages/core/*` |
-| SST v3 module | `packages/sst/*` |
+| SST v4 module | `packages/sst/*` |
 | CLI generator | `packages/cli/*` |
 | Shared types | `packages/base/*` |
 | React SDK | `packages/react/*` |

--- a/www/docs/packages.md
+++ b/www/docs/packages.md
@@ -13,7 +13,7 @@ Import from subpaths:
 ```ts
 import { createEntityConfig } from 'monorise/base';
 import { useEntities, useMutuals } from 'monorise/react';
-import { CoreFactory } from 'monorise/core';
+import CoreFactory from 'monorise/core';
 const { monorise } = await import('monorise/sst');
 ```
 

--- a/www/docs/react.md
+++ b/www/docs/react.md
@@ -9,18 +9,20 @@ Never point the React SDK directly at the monorise API Gateway. Always proxy thr
 ## Setup
 
 ```ts
-import { initMonorise } from 'monorise/react';
+import type { Entity, MonoriseEntityConfig } from 'monorise/base';
+import Monorise from 'monorise/react';
+import { EntityConfig } from '#/monorise';
 
-const monorise = initMonorise();
-export const {
-  useEntities,
-  useEntity,
-  useMutuals,
-  useTaggedEntities,
-  createEntity,
-  editEntity,
-  // ... all exports
-} = monorise;
+Monorise.config({
+  modals: {},
+  entityConfig: EntityConfig as Record<Entity, MonoriseEntityConfig>,
+});
+```
+
+Import hooks and actions as named exports after configuration:
+
+```ts
+import { createEntity, useEntities } from 'monorise/react';
 ```
 
 ## Caching
@@ -227,7 +229,7 @@ const {
 
 ### `useTaggedEntities`
 
-Fetch entities by tag with optional group and sort range filters.
+Fetch entities by tag using a group, prefix query, or sort range filter. Supply at least one filter in `params`; `refetch` and `listMore` currently require `params.group`.
 
 ```ts
 const {
@@ -406,9 +408,9 @@ Conditions are enforced at the database level via DynamoDB ConditionExpressions 
 Execute multiple entity operations atomically — all succeed or all fail. Uses DynamoDB `TransactWriteItems` under the hood.
 
 ```ts
-import { transaction, transactional } from 'monorise/react';
+import { coreService, transactional } from 'monorise/react';
 
-await transaction([
+await coreService.transaction([
   transactional.createEntity(Entity.ORDER, { customerId: '...', total: 5000 }),
   transactional.adjustEntity(Entity.WALLET, walletId, { balance: -5000, $condition: 'withdraw' }),
 ]);
@@ -419,7 +421,7 @@ The `transactional` builder provides autocomplete-friendly, type-safe operation 
 ```ts
 const tx = transactional;
 
-await transaction([
+await coreService.transaction([
   tx.createEntity(Entity.ORDER, { customerId: '...', total: 5000 }),
   tx.adjustEntity(Entity.WALLET, walletId, { balance: -5000, $condition: 'withdraw' }),
   tx.updateEntity(Entity.POST, postId, { status: 'published', $condition: 'publish' }),
@@ -464,4 +466,3 @@ When you call `createEntity`, `editEntity`, or `deleteEntity`, the store automat
 - **Delete**: Entity is removed from all mutual and tag stores
 
 This means `useMutuals` and `useTaggedEntities` reflect changes immediately without a manual refetch.
-

--- a/www/docs/react.md
+++ b/www/docs/react.md
@@ -229,7 +229,7 @@ const {
 
 ### `useTaggedEntities`
 
-Fetch entities by tag using a group, prefix query, or sort range filter. Supply at least one filter in `params`; `refetch` and `listMore` currently require `params.group`.
+Fetch entities by tag using a group, exact sort-value query, or sort range filter. Supply at least one filter in `params`; `refetch` and `listMore` currently require `params.group`.
 
 ```ts
 const {

--- a/www/docs/sst.md
+++ b/www/docs/sst.md
@@ -10,7 +10,7 @@ The SST SDK (`monorise/sst`) provides infrastructure constructs for deploying mo
 async run() {
   const { monorise } = await import('monorise/sst');
 
-  const { bus, api, table, alarmTopic } = new monorise.module.Core('core', {
+  const { bus, api, table, alarmTopic, xApiKey } = new monorise.module.Core('core', {
     allowOrigins: ['http://localhost:3000'],
   });
 
@@ -27,7 +27,7 @@ async run() {
 ```ts
 const { monorise } = await import('monorise/sst');
 
-const { bus, api, table, alarmTopic } = new monorise.module.Core('core', {
+const { bus, api, table, alarmTopic, xApiKey } = new monorise.module.Core('core', {
   allowOrigins: ['http://localhost:3000'],
   cloudwatchLogRetention: '1 week',
 });
@@ -69,7 +69,7 @@ When using `fromTableName`, the table must already enable DynamoDB Streams with 
 After construction, you can access the created resources to link them to other parts of your stack:
 
 ```ts
-const { bus, api, table, alarmTopic } = new monorise.module.Core('core', { ... });
+const { bus, api, table, alarmTopic, xApiKey } = new monorise.module.Core('core', { ... });
 
 // Link the API to a frontend
 new sst.aws.Nextjs('Web', {
@@ -90,6 +90,7 @@ bus.subscribe('custom-handler', {
 | `table` | `SingleTable` | DynamoDB single table with GSIs and replication |
 | `table.table` | `sst.aws.Dynamo` | The underlying DynamoDB table resource |
 | `alarmTopic` | `sst.aws.SnsTopic` | SNS topic for DLQ alarms. Reuse it when creating custom `QFunction` processors or attach your own subscriptions |
+| `xApiKey` | `sst.Secret` | Selected backend proxy key. Link it to the proxy and send its value as the `x-api-key` header |
 
 ### What it provisions
 
@@ -98,6 +99,7 @@ Under the hood, `MonoriseCore` creates:
 - **API Gateway v2** with CORS configuration
 - **DynamoDB single table** with primary index (`PK`/`SK`) and two GSIs for replication (`R1PK`/`R1SK`, `R2PK`/`R2SK`)
 - **EventBridge bus** for publishing entity events
+- **API key secrets** — rotatable `API_KEYS` allow-list for Core and selected `X_API_KEY` for backend proxies
 - **3 QFunction processors** (mutual, tag, tree) — each with SQS queue, Lambda, DLQ, and CloudWatch alarm
 - **Replication processor** — DynamoDB stream subscriber that keeps denormalized data in sync
 - **CloudWatch dashboard** with metrics for all Lambda functions, DLQ depths, and a link to DynamoDB table monitoring (can be disabled via `cloudwatchDashboard`)

--- a/www/docs/sst.md
+++ b/www/docs/sst.md
@@ -1,6 +1,6 @@
 # SST SDK
 
-The SST SDK (`monorise/sst`) provides infrastructure constructs for deploying monorise on AWS using [SST v3](https://sst.dev). It exports two building blocks:
+The SST SDK (`monorise/sst`) provides infrastructure constructs for deploying monorise on AWS using [SST v4](https://sst.dev). It exports two building blocks:
 
 - **`monorise.module.Core`** — the main construct that provisions the entire monorise infrastructure
 - **`monorise.block.QFunction`** — a reusable SQS + Lambda + DLQ + alarm pattern for building your own event processors
@@ -36,7 +36,7 @@ const { bus, api, table, alarmTopic } = new monorise.module.Core('core', {
 ### Constructor
 
 ```ts
-new MonoriseCore(id: string, args?: MonoriseCoreArgs)
+new monorise.module.Core(id: string, args?: MonoriseCoreArgs)
 ```
 
 | Arg | Type | Default | Description |
@@ -44,7 +44,8 @@ new MonoriseCore(id: string, args?: MonoriseCoreArgs)
 | `id` | `string` | — | Unique identifier for the construct (used in resource naming) |
 | `allowOrigins` | `string[]` | — | CORS allowed origins |
 | `allowHeaders` | `string[]` | `['Content-Type', 'Authorization']` | Additional CORS headers |
-| `slackWebhook` | `string` | — | Slack webhook URL for DLQ alerts |
+| `fromTableName` | `string` | — | Existing DynamoDB table name to reuse |
+| `slackWebhook` | `string` | — | Accepted for compatibility; it does not currently configure alert delivery |
 | `configRoot` | `string` | — | Custom root path for monorise config |
 | `cloudwatchLogRetention` | `sst.aws.FunctionArgs['logging']['retention']` | `'1 month'` | CloudWatch log retention period for Monorise-owned Lambda functions |
 | `cloudwatchDashboard` | `{ enabled?: boolean }` | `{ enabled: true }` | Built-in CloudWatch dashboard. Disable to skip creating it |
@@ -60,6 +61,8 @@ const { bus, api, table, alarmTopic } = new monorise.module.Core('core', {
 ```
 
 Disabling it on a stage where the dashboard already exists will destroy the dashboard on the next deploy.
+
+When using `fromTableName`, the table must already enable DynamoDB Streams with `NEW_AND_OLD_IMAGES`, provide Monorise's `R1` and `R2` GSIs, and enable TTL on `expiresAt`.
 
 ### Exposed resources
 
@@ -86,7 +89,7 @@ bus.subscribe('custom-handler', {
 | `bus` | `sst.aws.Bus` | EventBridge bus for entity lifecycle events |
 | `table` | `SingleTable` | DynamoDB single table with GSIs and replication |
 | `table.table` | `sst.aws.Dynamo` | The underlying DynamoDB table resource |
-| `alarmTopic` | `sst.aws.SnsTopic` | SNS topic for DLQ alarms — connected to Slack webhook notifications when `slackWebhook` is configured. Reuse this when creating custom `QFunction` processors to get alerts in the same Slack channel |
+| `alarmTopic` | `sst.aws.SnsTopic` | SNS topic for DLQ alarms. Reuse it when creating custom `QFunction` processors or attach your own subscriptions |
 
 ### What it provisions
 
@@ -95,7 +98,7 @@ Under the hood, `MonoriseCore` creates:
 - **API Gateway v2** with CORS configuration
 - **DynamoDB single table** with primary index (`PK`/`SK`) and two GSIs for replication (`R1PK`/`R1SK`, `R2PK`/`R2SK`)
 - **EventBridge bus** for publishing entity events
-- **3 QFunction processors** (mutual, tag, prejoin) — each with SQS queue, Lambda, DLQ, and CloudWatch alarm
+- **3 QFunction processors** (mutual, tag, tree) — each with SQS queue, Lambda, DLQ, and CloudWatch alarm
 - **Replication processor** — DynamoDB stream subscriber that keeps denormalized data in sync
 - **CloudWatch dashboard** with metrics for all Lambda functions, DLQ depths, and a link to DynamoDB table monitoring (can be disabled via `cloudwatchDashboard`)
 - **SST DevCommand** — automatically runs `monorise dev` in watch mode during `sst dev`
@@ -182,7 +185,7 @@ processor.id     // string — the construct ID
 2. The **Lambda function** processes messages (with `partialResponses` enabled for batch processing)
 3. Failed messages are retried, then moved to the **DLQ**
 4. If an `alarmTopic` is provided, a **CloudWatch alarm** fires when the DLQ has messages (`ApproximateNumberOfMessagesVisible >= 1`)
-5. The alarm triggers the SNS topic (e.g., Slack notification)
+5. The alarm triggers the SNS topic, which you can subscribe to with your preferred notification integration
 
 ### Use cases
 

--- a/www/docs/sst.md
+++ b/www/docs/sst.md
@@ -10,7 +10,7 @@ The SST SDK (`monorise/sst`) provides infrastructure constructs for deploying mo
 async run() {
   const { monorise } = await import('monorise/sst');
 
-  const { bus, api, table, alarmTopic, xApiKey } = new monorise.module.Core('core', {
+  const { bus, api, table, alarmTopic } = new monorise.module.Core('core', {
     allowOrigins: ['http://localhost:3000'],
   });
 
@@ -27,7 +27,7 @@ async run() {
 ```ts
 const { monorise } = await import('monorise/sst');
 
-const { bus, api, table, alarmTopic, xApiKey } = new monorise.module.Core('core', {
+const { bus, api, table, alarmTopic } = new monorise.module.Core('core', {
   allowOrigins: ['http://localhost:3000'],
   cloudwatchLogRetention: '1 week',
 });
@@ -69,7 +69,7 @@ When using `fromTableName`, the table must already enable DynamoDB Streams with 
 After construction, you can access the created resources to link them to other parts of your stack:
 
 ```ts
-const { bus, api, table, alarmTopic, xApiKey } = new monorise.module.Core('core', { ... });
+const { bus, api, table, alarmTopic } = new monorise.module.Core('core', { ... });
 
 // Link the API to a frontend
 new sst.aws.Nextjs('Web', {
@@ -90,7 +90,6 @@ bus.subscribe('custom-handler', {
 | `table` | `SingleTable` | DynamoDB single table with GSIs and replication |
 | `table.table` | `sst.aws.Dynamo` | The underlying DynamoDB table resource |
 | `alarmTopic` | `sst.aws.SnsTopic` | SNS topic for DLQ alarms. Reuse it when creating custom `QFunction` processors or attach your own subscriptions |
-| `xApiKey` | `sst.Secret` | Selected backend proxy key. Link it to the proxy and send its value as the `x-api-key` header |
 
 ### What it provisions
 
@@ -99,7 +98,6 @@ Under the hood, `MonoriseCore` creates:
 - **API Gateway v2** with CORS configuration
 - **DynamoDB single table** with primary index (`PK`/`SK`) and two GSIs for replication (`R1PK`/`R1SK`, `R2PK`/`R2SK`)
 - **EventBridge bus** for publishing entity events
-- **API key secrets** — rotatable `API_KEYS` allow-list for Core and selected `X_API_KEY` for backend proxies
 - **3 QFunction processors** (mutual, tag, tree) — each with SQS queue, Lambda, DLQ, and CloudWatch alarm
 - **Replication processor** — DynamoDB stream subscriber that keeps denormalized data in sync
 - **CloudWatch dashboard** with metrics for all Lambda functions, DLQ depths, and a link to DynamoDB table monitoring (can be disabled via `cloudwatchDashboard`)


### PR DESCRIPTION
## Summary

- Preserve the existing tree processor decision guidance while correcting its trigger, traversal, and processor examples.
- Recommend shared `createMutualConfig` definitions and add valid condition, mutual-data, tag, React SDK, and SST v4 examples.
- Separate the rotatable Core `API_KEYS` allow-list from the application-owned backend proxy `X_API_KEY`; generated projects create and link the selected proxy secret without changing `MonoriseCore`.
- Return 404 when a named function update condition targets a missing entity, matching adjustment behavior.
- Remove unsupported Slack webhook claims and other outdated API references.

## Validation

- `npm -w @monorise/core test -- ConditionalUpdateEntityHttp.test.ts`
- `npm -w @monorise/core run build`
- `npm -w @monorise/sst run build`
- `npm -w @monorise/cli run build`
- `npm run docs:build`
- `openspec validate refresh-documentation --strict`