### PR TITLE
fix(react): stop entity edits overwriting flipped mutual data

### DIFF
--- a/.changeset/cuddly-meteors-crash.md
+++ b/.changeset/cuddly-meteors-crash.md
@@ -1,0 +1,5 @@
+---
+"@monorise/react": patch
+---
+
+fix: update local mutual state

--- a/.changeset/cuddly-meteors-crash.md
+++ b/.changeset/cuddly-meteors-crash.md
@@ -2,4 +2,4 @@
 "@monorise/react": patch
 ---
 
-fix: update local mutual state
+fix: stop entity edits overwriting flipped mutual data, and propagate updates to chained mutual slices

--- a/packages/react/actions/core.action.ts
+++ b/packages/react/actions/core.action.ts
@@ -21,6 +21,7 @@ import {
   getTagStateKey,
   getUniqueFieldRequestKey,
   getUniqueFieldStateKey,
+  parseMutualStateKey,
 } from '../lib/utils';
 import type {
   CommonOptions,
@@ -676,26 +677,14 @@ const initCoreActions = (
 
           // update mutual's entity data
           for (const key of Object.keys(state.mutual)) {
-            const [_byEntity, _byId, _entityType] = key.split('/');
-            if ((_entityType as unknown as Entity) === entityType) {
+            const { entity: mutualEntityType } = parseMutualStateKey(key);
+            if (mutualEntityType === entityType) {
               const mutual = state.mutual[key].dataMap.get(id);
               if (mutual) {
                 state.mutual[key].dataMap = new Map(
                   state.mutual[key].dataMap,
                 ).set(id, { ...mutual, data: data.data });
               }
-            }
-          }
-
-          // update flipped mutual side (entity is the "by" entity)
-          for (const key of Object.keys(state.mutual)) {
-            const [_byEntity, _byId] = key.split('/');
-            if ((_byEntity as unknown as Entity) === entityType && _byId === id) {
-              const newDataMap = new Map(state.mutual[key].dataMap);
-              for (const [entryId, mutual] of newDataMap) {
-                newDataMap.set(entryId, { ...mutual, data: data.data });
-              }
-              state.mutual[key].dataMap = newDataMap;
             }
           }
 
@@ -739,25 +728,14 @@ const initCoreActions = (
 
           // Propagate to mutual stores
           for (const key of Object.keys(state.mutual)) {
-            const [_byEntity, _byId, _entityType] = key.split('/');
-            if ((_entityType as unknown as Entity) === entityType) {
+            const { entity: mutualEntityType } = parseMutualStateKey(key);
+            if (mutualEntityType === entityType) {
               const mutual = state.mutual[key].dataMap.get(id);
               if (mutual) {
                 state.mutual[key].dataMap = new Map(
                   state.mutual[key].dataMap,
                 ).set(id, { ...(mutual as any), data: data.data });
               }
-            }
-          }
-
-          for (const key of Object.keys(state.mutual)) {
-            const [_byEntity, _byId] = key.split('/');
-            if ((_byEntity as unknown as Entity) === entityType && _byId === id) {
-              const newDataMap = new Map(state.mutual[key].dataMap);
-              for (const [entryId, mutual] of newDataMap) {
-                newDataMap.set(entryId, { ...(mutual as any), data: data.data });
-              }
-              state.mutual[key].dataMap = newDataMap;
             }
           }
 
@@ -807,8 +785,8 @@ const initCoreActions = (
 
           // delete mutual's entity data
           for (const key of Object.keys(state.mutual)) {
-            const [_byEntity, _byId, _entityType] = key.split('/');
-            if ((_entityType as unknown as Entity) === entityType) {
+            const { entity: mutualEntityType } = parseMutualStateKey(key);
+            if (mutualEntityType === entityType) {
               state.mutual[key].dataMap.delete(id);
             }
           }

--- a/packages/react/lib/utils.ts
+++ b/packages/react/lib/utils.ts
@@ -23,6 +23,24 @@ export const getMutualStateKey = (
   return `${byEntity}/${byEntityId}/${entity}${entityId ? `/${entityId}` : ''}${chainEntityQuery ? `?${chainEntityQuery}` : ''}`;
 };
 
+// inverse of getMutualStateKey — the chain query is stripped off first so that
+// it never leaks into the trailing path segment
+export const parseMutualStateKey = (stateKey: string) => {
+  const queryIndex = stateKey.indexOf('?');
+  const path = queryIndex === -1 ? stateKey : stateKey.slice(0, queryIndex);
+  const chainEntityQuery =
+    queryIndex === -1 ? undefined : stateKey.slice(queryIndex + 1);
+  const [byEntity, byEntityId, entity, entityId] = path.split('/');
+
+  return {
+    byEntity: byEntity as unknown as Entity,
+    byEntityId,
+    entity: entity as unknown as Entity,
+    entityId,
+    chainEntityQuery,
+  };
+};
+
 export const getTagStateKey = (
   entityType: Entity,
   tagName: string,


### PR DESCRIPTION
## Summary

- Drop the "flipped mutual side" propagation loops from `editEntity` and `adjustEntity`, which overwrote unrelated mutual entries with the edited entity's data.
- Add `parseMutualStateKey` to `@monorise/react` as the inverse of `getMutualStateKey`, stripping the chain query before splitting the path.
- Use it for the mutual store scans in `editEntity`, `adjustEntity`, and `deleteEntity` so chained state keys resolve to the right entity type.
- Add a patch release for `@monorise/react`.

## Why

A mutual slice keyed `A/aId/B` holds entries keyed by `B` ids, and each entry's `data` is that `B` entity's data — `flipMutual` preserves this on the reverse side too. The removed loops matched every key whose *by* entity was the edited type and id (`T/id/Other`), then rewrote **every** entry's `data` with the edited entity's payload, so each `Other` entry ended up carrying a `T` entity's data. Editing an entity corrupted the flipped mutual slices in the store.

The remaining loop already covers the real propagation: it matches keys whose listed entity type is the edited type and patches the single entry at that id. Since the flipped side is stored under its own key with the same invariant, there is no second location holding the edited entity's data, and `Mutual` carries no by-entity data field. The loops were redundant on top of being wrong.

Separately, those scans read the entity type as `key.split('/')[2]`. `listEntitiesByEntity` builds chained keys as `A/aId/B?chain=...`, so that segment was `B?chain=...` and never matched an entity type — mutuals in chained slices were silently skipped on edit, adjust, and delete. `parseMutualStateKey` cuts at the first `?` before splitting, so those slices are now updated and removed with the rest.

## Verification

- `npx tsc --noEmit` in `packages/react`: same two pre-existing errors as `main` (`core.action.ts:467`, `core.action.ts:498`); the deletion also cleared a third pre-existing error inside the removed loop.
- `biome check packages/react/actions/core.action.ts`: finding count unchanged from `main`.

## Follow-up

- `listEntitiesByEntity` accepts an `opts.stateKey` override that can register a mutual slice under an arbitrary key. Such slices remain invisible to all three scans, since the key cannot be parsed back into an entity type. Worth deciding whether custom state keys are meant to opt out of propagation.
